### PR TITLE
fix: Fix missing checks on product include/exclude glob for attestation.

### DIFF
--- a/attestation/file/file.go
+++ b/attestation/file/file.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/edwarnicke/gitoid"
+	"github.com/gobwas/glob"
 	"github.com/testifysec/go-witness/cryptoutil"
 	"github.com/testifysec/go-witness/log"
 )
@@ -28,7 +29,7 @@ import (
 // recordArtifacts will walk basePath and record the digests of each file with each of the functions in hashes.
 // If file already exists in baseArtifacts and the two artifacts are equal the artifact will not be in the
 // returned map of artifacts.
-func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []crypto.Hash, visitedSymlinks map[string]struct{}) (map[string]cryptoutil.DigestSet, error) {
+func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []crypto.Hash, visitedSymlinks map[string]struct{}, includeGlob glob.Glob, excludeGlob glob.Glob) (map[string]cryptoutil.DigestSet, error) {
 	artifacts := make(map[string]cryptoutil.DigestSet)
 	err := filepath.Walk(basePath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -59,7 +60,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			}
 
 			visitedSymlinks[linkedPath] = struct{}{}
-			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks)
+			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks, includeGlob, excludeGlob)
 			if err != nil {
 				return err
 			}
@@ -67,7 +68,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			for artifactPath, artifact := range symlinkedArtifacts {
 				// all artifacts in the symlink should be recorded relative to our basepath
 				joinedPath := filepath.Join(relPath, artifactPath)
-				if shouldRecord(joinedPath, artifact, baseArtifacts) {
+				if shouldRecord(joinedPath, artifact, baseArtifacts, includeGlob, excludeGlob) {
 					artifacts[filepath.Join(relPath, artifactPath)] = artifact
 				}
 			}
@@ -105,7 +106,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			GitOID: true,
 		}] = goidSha256.URI()
 
-		if shouldRecord(relPath, artifact, baseArtifacts) {
+		if shouldRecord(relPath, artifact, baseArtifacts, includeGlob, excludeGlob) {
 			artifacts[relPath] = artifact
 		}
 
@@ -118,7 +119,20 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 // shouldRecord determines whether artifact should be recorded.
 // if the artifact is already in baseArtifacts, check if it's changed
 // if it is not equal to the existing artifact, return true, otherwise return false
-func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet) bool {
+func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet, includeGlob glob.Glob, excludeGlob glob.Glob) bool {
+
+	includePath := true
+	if excludeGlob != nil && excludeGlob.Match(path) {
+		includePath = false
+	}
+	if includeGlob != nil && includeGlob.Match(path) {
+		includePath = true
+	}
+
+	if !includePath {
+		return false
+	}
+
 	if previous, ok := baseArtifacts[path]; ok && artifact.Equal(previous) {
 		return false
 	}

--- a/attestation/file/file_test.go
+++ b/attestation/file/file_test.go
@@ -38,13 +38,13 @@ func TestBrokenSymlink(t *testing.T) {
 	symTestDir := filepath.Join(dir, "symTestDir")
 	require.NoError(t, os.Symlink(testDir, symTestDir))
 
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []crypto.Hash{crypto.SHA256}, map[string]struct{}{})
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []crypto.Hash{crypto.SHA256}, map[string]struct{}{}, nil, nil)
 	require.NoError(t, err)
 
 	// remove the symlinks and make sure we don't get an error back
 	require.NoError(t, os.RemoveAll(testDir))
 	require.NoError(t, os.RemoveAll(testFile))
-	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []crypto.Hash{crypto.SHA256}, map[string]struct{}{})
+	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []crypto.Hash{crypto.SHA256}, map[string]struct{}{}, nil, nil)
 	require.NoError(t, err)
 }
 
@@ -58,6 +58,6 @@ func TestSymlinkCycle(t *testing.T) {
 	require.NoError(t, os.Symlink(dir, symTestDir))
 
 	// if a symlink cycle weren't properly handled this would be an infinite loop
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []crypto.Hash{crypto.SHA256}, map[string]struct{}{})
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []crypto.Hash{crypto.SHA256}, map[string]struct{}{}, nil, nil)
 	require.NoError(t, err)
 }

--- a/attestation/material/material.go
+++ b/attestation/material/material.go
@@ -69,7 +69,7 @@ func New(opts ...Option) *Attestor {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{})
+	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{}, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/attestation/product/product.go
+++ b/attestation/product/product.go
@@ -164,7 +164,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	a.compiledExcludeGlob = compiledExcludeGlob
 
 	a.baseArtifacts = ctx.Materials()
-	products, err := file.RecordArtifacts(ctx.WorkingDir(), a.baseArtifacts, ctx.Hashes(), map[string]struct{}{})
+	products, err := file.RecordArtifacts(ctx.WorkingDir(), a.baseArtifacts, ctx.Hashes(), map[string]struct{}{}, compiledIncludeGlob, compiledExcludeGlob)
 	if err != nil {
 		return err
 	}
@@ -194,15 +194,18 @@ func (a *Attestor) Products() map[string]attestation.Product {
 func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	subjects := make(map[string]cryptoutil.DigestSet)
 	for productName, product := range a.products {
+
+		includeSubject := true
 		if a.compiledExcludeGlob != nil && a.compiledExcludeGlob.Match(productName) {
-			continue
+			includeSubject = false
+		}
+		if a.compiledIncludeGlob != nil && a.compiledIncludeGlob.Match(productName) {
+			includeSubject = true
 		}
 
-		if a.compiledIncludeGlob != nil && !a.compiledIncludeGlob.Match(productName) {
-			continue
+		if includeSubject {
+			subjects[fmt.Sprintf("file:%v", productName)] = product.Digest
 		}
-
-		subjects[fmt.Sprintf("file:%v", productName)] = product.Digest
 	}
 
 	return subjects


### PR DESCRIPTION
This change addresses a problem with `--attestor-product-exclude-glob` and `--attestor-product-include-glob` they only worked for the Subject collection, but not for the Product attestation. Also it did not allow for include overwriting the exclude on sub elements.

Changes:
- It add the two glob arguments to the `RecordArtifacts`. These allow you to pass glob statements the same way they are created in Product attestor for the arguments.
- All references are updated to pass `nil` where the do not have a implementation. This is a breaking change for any API contract for those using this as a library. So maybe I need to change the commit to `fix!:` for breaking change depending on the way we want to maintain contracts.
- The `Product.Subjects()` and `File.shouldRecord()` command now allow for include to take precedence over the exclude.

Fixes #65 