### PR TITLE
Fixing bug introduced in logs - warning and debug logs not printing

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -58,8 +58,11 @@ func Warnf(format string, args ...interface{}) {
 		if _, ok := a.(error); ok {
 			err := fmt.Errorf(format, args...)
 			log.Warn(err)
+			return
 		}
 	}
+
+	log.Warnf(format, args...)
 }
 
 func Warn(args ...interface{}) {
@@ -71,8 +74,11 @@ func Debugf(format string, args ...interface{}) {
 		if _, ok := a.(error); ok {
 			err := fmt.Errorf(format, args...)
 			log.Debug(err)
+			return
 		}
 	}
+
+	log.Debugf(format, args...)
 }
 
 func Debug(args ...interface{}) {


### PR DESCRIPTION
I introduced a bug as I was not returning and otherwise logging as usual if an error wasn't found. This PR fixes that. See https://github.com/in-toto/go-witness/pull/85 for introduction of the original issue.