### PR TITLE
WIP: Defining an interface for allowing signing and verifying with different envelope types

### DIFF
--- a/cryptoutil/ecdsa.go
+++ b/cryptoutil/ecdsa.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
+	"crypto/x509"
 )
 
 type ErrVerifyFailed struct{}
@@ -38,6 +39,14 @@ func NewECDSASigner(priv *ecdsa.PrivateKey, hash crypto.Hash) *ECDSASigner {
 
 func (s *ECDSASigner) KeyID() (string, error) {
 	return GeneratePublicKeyID(&s.priv.PublicKey, s.hash)
+}
+
+func (s *ECDSASigner) Algorithm() (x509.PublicKeyAlgorithm, crypto.Hash) {
+	return x509.ECDSA, s.hash
+}
+
+func (s *ECDSASigner) Signer() (crypto.Signer, error) {
+	return s.priv, nil
 }
 
 func (s *ECDSASigner) Sign(ctx context.Context, data []byte) ([]byte, error) {

--- a/cryptoutil/ecdsa.go
+++ b/cryptoutil/ecdsa.go
@@ -15,10 +15,10 @@
 package cryptoutil
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
-	"io"
 )
 
 type ErrVerifyFailed struct{}
@@ -40,8 +40,8 @@ func (s *ECDSASigner) KeyID() (string, error) {
 	return GeneratePublicKeyID(&s.priv.PublicKey, s.hash)
 }
 
-func (s *ECDSASigner) Sign(r io.Reader) ([]byte, error) {
-	digest, err := Digest(r, s.hash)
+func (s *ECDSASigner) Sign(ctx context.Context, data []byte) ([]byte, error) {
+	digest, err := DigestBytes(data, s.hash)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +66,8 @@ func (v *ECDSAVerifier) KeyID() (string, error) {
 	return GeneratePublicKeyID(v.pub, v.hash)
 }
 
-func (v *ECDSAVerifier) Verify(data io.Reader, sig []byte) error {
-	digest, err := Digest(data, v.hash)
+func (v *ECDSAVerifier) Verify(ctx context.Context, data []byte, sig []byte) error {
+	digest, err := DigestBytes(data, v.hash)
 	if err != nil {
 		return err
 	}
@@ -78,6 +78,10 @@ func (v *ECDSAVerifier) Verify(data io.Reader, sig []byte) error {
 	}
 
 	return nil
+}
+
+func (v *ECDSAVerifier) Public() crypto.PublicKey {
+	return v.pub
 }
 
 func (v *ECDSAVerifier) Bytes() ([]byte, error) {

--- a/cryptoutil/ed25519.go
+++ b/cryptoutil/ed25519.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ed25519"
+	"crypto/x509"
 	"fmt"
 )
 
@@ -57,6 +58,14 @@ func NewED25519Verifier(pub ed25519.PublicKey) *ED25519Verifier {
 
 func (v *ED25519Verifier) KeyID() (string, error) {
 	return GeneratePublicKeyID(v.pub, crypto.SHA256)
+}
+
+func (s *ED25519Signer) Algorithm() (x509.PublicKeyAlgorithm, crypto.Hash) {
+	return x509.Ed25519, 0
+}
+
+func (s *ED25519Signer) Signer() (crypto.Signer, error) {
+	return s.priv, nil
 }
 
 func (v *ED25519Verifier) Verify(ctx context.Context, payload []byte, sig []byte) error {

--- a/cryptoutil/rsa.go
+++ b/cryptoutil/rsa.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 )
 
 type RSASigner struct {
@@ -32,6 +33,14 @@ func NewRSASigner(priv *rsa.PrivateKey, hash crypto.Hash) *RSASigner {
 
 func (s *RSASigner) KeyID() (string, error) {
 	return GeneratePublicKeyID(&s.priv.PublicKey, s.hash)
+}
+
+func (s *RSASigner) Algorithm() (x509.PublicKeyAlgorithm, crypto.Hash) {
+	return x509.RSA, s.hash
+}
+
+func (s *RSASigner) Signer() (crypto.Signer, error) {
+	return s.priv, nil
 }
 
 func (s *RSASigner) Sign(ctx context.Context, data []byte) ([]byte, error) {

--- a/cryptoutil/rsa.go
+++ b/cryptoutil/rsa.go
@@ -15,10 +15,10 @@
 package cryptoutil
 
 import (
+	"context"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"io"
 )
 
 type RSASigner struct {
@@ -34,8 +34,8 @@ func (s *RSASigner) KeyID() (string, error) {
 	return GeneratePublicKeyID(&s.priv.PublicKey, s.hash)
 }
 
-func (s *RSASigner) Sign(r io.Reader) ([]byte, error) {
-	digest, err := Digest(r, s.hash)
+func (s *RSASigner) Sign(ctx context.Context, data []byte) ([]byte, error) {
+	digest, err := DigestBytes(data, s.hash)
 	if err != nil {
 		return nil, err
 	}
@@ -65,8 +65,8 @@ func (v *RSAVerifier) KeyID() (string, error) {
 	return GeneratePublicKeyID(v.pub, v.hash)
 }
 
-func (v *RSAVerifier) Verify(data io.Reader, sig []byte) error {
-	digest, err := Digest(data, v.hash)
+func (v *RSAVerifier) Verify(ctx context.Context, data []byte, sig []byte) error {
+	digest, err := DigestBytes(data, v.hash)
 	if err != nil {
 		return err
 	}
@@ -77,6 +77,10 @@ func (v *RSAVerifier) Verify(data io.Reader, sig []byte) error {
 	}
 
 	return rsa.VerifyPSS(v.pub, v.hash, digest, sig, pssOpts)
+}
+
+func (v *RSAVerifier) Public() crypto.PublicKey {
+	return v.pub
 }
 
 func (v *RSAVerifier) Bytes() ([]byte, error) {

--- a/cryptoutil/signer.go
+++ b/cryptoutil/signer.go
@@ -15,6 +15,7 @@
 package cryptoutil
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -32,15 +33,22 @@ func (e ErrUnsupportedKeyType) Error() string {
 	return fmt.Sprintf("unsupported signer key type: %v", e.t)
 }
 
-type Signer interface {
-	KeyIdentifier
-	Sign(r io.Reader) ([]byte, error)
-	Verifier() (Verifier, error)
+type SignerVerifier struct {
+	Signer
+	Verifier
 }
 
-type KeyIdentifier interface {
-	KeyID() (string, error)
+// NOTE: Signer verifier required this function and I don't know why
+func (sv SignerVerifier) KeyID() (string, error) {
+	return sv.Signer.KeyID()
 }
+
+type Signer interface {
+	KeyID() (string, error)
+	Sign(ctx context.Context, data []byte) ([]byte, error)
+}
+
+type KeyIdentifier interface{}
 
 type TrustBundler interface {
 	Certificate() *x509.Certificate

--- a/cryptoutil/signer.go
+++ b/cryptoutil/signer.go
@@ -46,6 +46,8 @@ func (sv SignerVerifier) KeyID() (string, error) {
 type Signer interface {
 	KeyID() (string, error)
 	Sign(ctx context.Context, data []byte) ([]byte, error)
+	Algorithm() (x509.PublicKeyAlgorithm, crypto.Hash)
+	Signer() (crypto.Signer, error)
 }
 
 type KeyIdentifier interface{}

--- a/cryptoutil/signer.go
+++ b/cryptoutil/signer.go
@@ -38,11 +38,6 @@ type SignerVerifier struct {
 	Verifier
 }
 
-// NOTE: Signer verifier required this function and I don't know why
-func (sv SignerVerifier) KeyID() (string, error) {
-	return sv.Signer.KeyID()
-}
-
 type Signer interface {
 	KeyID() (string, error)
 	Sign(ctx context.Context, data []byte) ([]byte, error)

--- a/cryptoutil/util.go
+++ b/cryptoutil/util.go
@@ -78,9 +78,6 @@ func PublicPemBytes(pub interface{}) ([]byte, error) {
 	}
 
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: keyBytes})
-	if err != nil {
-		return nil, err
-	}
 
 	return pemBytes, err
 }

--- a/cryptoutil/verifier.go
+++ b/cryptoutil/verifier.go
@@ -15,6 +15,7 @@
 package cryptoutil
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -26,9 +27,9 @@ import (
 )
 
 type Verifier interface {
-	KeyIdentifier
-	Verify(body io.Reader, sig []byte) error
-	Bytes() ([]byte, error)
+	Verify(ctx context.Context, data, sig []byte) error
+	KeyID() (string, error)
+	Public() crypto.PublicKey
 }
 
 type VerifierOption func(*verifierOptions)

--- a/cryptoutil/x509.go
+++ b/cryptoutil/x509.go
@@ -139,6 +139,14 @@ func (s *X509Signer) KeyID() (string, error) {
 	return s.signer.KeyID()
 }
 
+func (s *X509Signer) Algorithm() (x509.PublicKeyAlgorithm, crypto.Hash) {
+	return s.signer.Algorithm()
+}
+
+func (s *X509Signer) Signer() (crypto.Signer, error) {
+	return s.signer.Signer()
+}
+
 func (s *X509Signer) Sign(ctx context.Context, data []byte) ([]byte, error) {
 	return s.signer.Sign(ctx, data)
 }

--- a/dsse/dsse.go
+++ b/dsse/dsse.go
@@ -48,7 +48,7 @@ func (e ErrInvalidThreshold) Error() string {
 const PemTypeCertificate = "CERTIFICATE"
 
 type Envelope struct {
-	Payload     []byte      `json:"payload"`
+	Payload     string      `json:"payload"`
 	PayloadType string      `json:"payloadType"`
 	Signatures  []Signature `json:"signatures"`
 }

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -17,6 +17,7 @@ package dsse
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -59,7 +60,7 @@ func Sign(bodyType string, body []byte, opts ...SignOption) (Envelope, error) {
 	}
 
 	env.PayloadType = bodyType
-	env.Payload = string(body)
+	env.Payload = base64.StdEncoding.EncodeToString(body)
 	env.Signatures = make([]Signature, 0)
 	pae := preauthEncode(bodyType, body)
 	for _, signer := range so.signers {

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -59,7 +59,7 @@ func Sign(bodyType string, body []byte, opts ...SignOption) (Envelope, error) {
 	}
 
 	env.PayloadType = bodyType
-	env.Payload = body
+	env.Payload = string(body)
 	env.Signatures = make([]Signature, 0)
 	pae := preauthEncode(bodyType, body)
 	for _, signer := range so.signers {

--- a/dsse/sign.go
+++ b/dsse/sign.go
@@ -47,7 +47,7 @@ func SignWithTimestampers(timestampers ...Timestamper) SignOption {
 	}
 }
 
-func Sign(bodyType string, body io.Reader, opts ...SignOption) (Envelope, error) {
+func Sign(bodyType string, body []byte, opts ...SignOption) (Envelope, error) {
 	so := &signOptions{}
 	env := Envelope{}
 	for _, opt := range opts {
@@ -58,17 +58,12 @@ func Sign(bodyType string, body io.Reader, opts ...SignOption) (Envelope, error)
 		return env, fmt.Errorf("must have at least one signer, have %v", len(so.signers))
 	}
 
-	bodyBytes, err := io.ReadAll(body)
-	if err != nil {
-		return env, err
-	}
-
 	env.PayloadType = bodyType
-	env.Payload = bodyBytes
+	env.Payload = body
 	env.Signatures = make([]Signature, 0)
-	pae := preauthEncode(bodyType, bodyBytes)
+	pae := preauthEncode(bodyType, body)
 	for _, signer := range so.signers {
-		sig, err := signer.Sign(bytes.NewReader(pae))
+		sig, err := signer.Sign(context.TODO(), pae)
 		if err != nil {
 			return env, err
 		}

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -86,7 +86,7 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]PassedVerifier, error) {
 		return nil, ErrInvalidThreshold(options.threshold)
 	}
 
-	pae := preauthEncode(e.PayloadType, e.Payload)
+	pae := preauthEncode(e.PayloadType, []byte(e.Payload))
 	if len(e.Signatures) == 0 {
 		return nil, ErrNoSignatures{}
 	}
@@ -146,7 +146,7 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]PassedVerifier, error) {
 
 		for _, verifier := range options.verifiers {
 			if verifier != nil {
-				if err := verifier.Verify(bytes.NewReader(pae), sig.Signature); err == nil {
+				if err := verifier.Verify(context.TODO(), pae, sig.Signature); err == nil {
 					passedVerifiers = append(passedVerifiers, PassedVerifier{Verifier: verifier})
 					matchingSigFound = true
 				}
@@ -171,7 +171,7 @@ func verifyX509Time(cert *x509.Certificate, sigIntermediates, roots []*x509.Cert
 		return nil, err
 	}
 
-	if err := verifier.Verify(bytes.NewReader(pae), sig); err != nil {
+	if err := verifier.Verify(context.TODO(), pae, sig); err != nil {
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/coreos/go-oidc/v3 v3.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -50,6 +51,8 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
+	github.com/veraison/go-cose v1.1.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/mod v0.10.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/pjbgf/sha1cd v0.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
 	github.com/segmentio/ksuid v1.0.4 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/facebookgo/limitgroup v0.0.0-20150612190941-6abd8d71ec01 h1:IeaD1VDVB
 github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52 h1:a4DFiKFJiDRGFD1qIcqGLX/WlUMD9dyLSLDt+9QZgt8=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/foxcpp/go-mockdns v0.0.0-20210729171921-fb145fc6f897 h1:E52jfcE64UG42SwLmrW0QByONfGynWuzBvm86BoB9z8=
+github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
+github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
@@ -206,11 +208,15 @@ github.com/theupdateframework/go-tuf v0.5.2-0.20220930112810-3890c1e7ace4 h1:1i/
 github.com/theupdateframework/go-tuf v0.5.2-0.20220930112810-3890c1e7ace4/go.mod h1:vAqWV3zEs89byeFsAYoh/Q14vJTgJkHwnnRCWBBBINY=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
+github.com/veraison/go-cose v1.1.0 h1:AalPS4VGiKavpAzIlBjrn7bhqXiXi4jbMYY/2+UC+4o=
+github.com/veraison/go-cose v1.1.0/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/secure-systems-lab/go-securesystemslib v0.7.0 h1:OwvJ5jQf9LnIAS83waAjPbcMsODrTQUpJ02eNLUoxBg=
+github.com/secure-systems-lab/go-securesystemslib v0.7.0/go.mod h1:/2gYnlnHVQ6xeGtfIqFy7Do03K4cdCY0A/GlJLDKLHI=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/signature/envelope/cose/cose.go
+++ b/signature/envelope/cose/cose.go
@@ -12,11 +12,12 @@ import (
 	cose "github.com/veraison/go-cose"
 )
 
+// Envelope is a wrapper around the COSE envelope that implements the Envelope interface.
 type Envelope struct {
 	Envelope *cose.Sign1Message
 }
 
-// NewEnvelope creates a new envelope from specified payload type and non-base64 encoded payload
+// NewEnvelope creates a new envelope from specified payload type and non-base64 encoded payload.
 func NewEnvelope(payloadType string, payload []byte) (*Envelope, error) {
 	// simple if statement to detect if payload is base64 encoded
 	// NOTE: not sure if this is helpful
@@ -38,6 +39,7 @@ func NewEnvelope(payloadType string, payload []byte) (*Envelope, error) {
 	}, nil
 }
 
+// Sign signs the payload with the specified signer and options.
 func (e *Envelope) Sign(signer *cryptoutil.Signer, opts ...envelope.EnvelopeOption) error {
 	// create an io.Reader for a random string
 	alg, err := getSignerAlg(*signer)
@@ -66,10 +68,12 @@ func (e *Envelope) Sign(signer *cryptoutil.Signer, opts ...envelope.EnvelopeOpti
 	return nil
 }
 
+// Content returns the envelope content for use in other operations.
 func (e *Envelope) Content() (*envelope.EnvelopeContent, error) {
 	return nil, nil
 }
 
+// Verify verifies the envelope against the public key verifier in the input.
 func (e *Envelope) Verify(v *cryptoutil.Verifier) error {
 	return nil
 }

--- a/signature/envelope/cose/cose.go
+++ b/signature/envelope/cose/cose.go
@@ -1,0 +1,108 @@
+package cose
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/signature/envelope"
+	cose "github.com/veraison/go-cose"
+)
+
+type Envelope struct {
+	Envelope *cose.Sign1Message
+}
+
+// NewEnvelope creates a new envelope from specified payload type and non-base64 encoded payload
+func NewEnvelope(payloadType string, payload []byte) (*Envelope, error) {
+	// simple if statement to detect if payload is base64 encoded
+	// NOTE: not sure if this is helpful
+	if _, err := base64.StdEncoding.DecodeString(string(payload)); err == nil {
+		return nil, fmt.Errorf("please supply payload as a non-base64 encoded byte array")
+	}
+
+	// create message header
+	return &Envelope{
+		Envelope: &cose.Sign1Message{
+			Headers: cose.Headers{
+				Protected: cose.ProtectedHeader{
+					cose.HeaderLabelContentType: payloadType,
+				},
+			},
+
+			Payload: payload,
+		},
+	}, nil
+}
+
+func (e *Envelope) Sign(signer *cryptoutil.Signer, opts ...envelope.EnvelopeOption) error {
+	// create an io.Reader for a random string
+	alg, err := getSignerAlg(*signer)
+	if err != nil {
+		return err
+	}
+
+	// we need to set the algorithm in the protected header
+	e.Envelope.Headers.Protected[cose.HeaderLabelAlgorithm] = alg
+
+	s, err := (*signer).Signer()
+	if err != nil {
+		return err
+	}
+
+	csigner, err := cose.NewSigner(alg, s)
+	if err != nil {
+		return err
+	}
+
+	err = e.Envelope.Sign(rand.Reader, nil, csigner)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *Envelope) Content() (*envelope.EnvelopeContent, error) {
+	return nil, nil
+}
+
+func (e *Envelope) Verify(v *cryptoutil.Verifier) error {
+	return nil
+}
+
+// NOTE: Don't like embedded switch statements, but not sure what else I can do
+func getSignerAlg(signer cryptoutil.Signer) (cose.Algorithm, error) {
+	alg, hash := signer.Algorithm()
+	switch alg {
+	case x509.ECDSA:
+		switch hash {
+		case crypto.SHA256:
+			return cose.AlgorithmES256, nil
+		case crypto.SHA384:
+			return cose.AlgorithmES384, nil
+		case crypto.SHA512:
+			return cose.AlgorithmES512, nil
+		default:
+			return cose.Algorithm(-1), fmt.Errorf("unsupported hash algorithm: %v", hash)
+		}
+	case x509.RSA:
+		switch hash {
+		case crypto.SHA256:
+			return cose.AlgorithmPS256, nil
+		case crypto.SHA384:
+			return cose.AlgorithmPS384, nil
+		case crypto.SHA512:
+			return cose.AlgorithmPS512, nil
+		default:
+			return cose.Algorithm(-1), fmt.Errorf("unsupported hash algorithm: %v", hash)
+		}
+	case x509.Ed25519:
+		return cose.AlgorithmEd25519, nil
+	default:
+		return cose.Algorithm(-1), fmt.Errorf("unsupported algorithm: %v", alg)
+	}
+}

--- a/signature/envelope/dsse/dsse.go
+++ b/signature/envelope/dsse/dsse.go
@@ -1,49 +1,58 @@
 package dsse
 
 import (
-	"crypto"
 	"fmt"
 
 	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/signature/envelope"
+
 	// Eventually we will migrate to using github.com/securesystemslab/dsse
 	// but for now it doesn't support timestamps and intermediates
 	idsse "github.com/in-toto/go-witness/dsse"
 )
 
-type DSSEEnvelope struct {
+type Envelope struct {
 	Envelope *idsse.Envelope
 }
 
-func (e *DSSEEnvelope) Sign(signer *crypto.Signer, opts ...cryptoutil.SignerOption) (interface{}, error) {
+func (e *Envelope) Sign(signer *cryptoutil.Signer) error {
 	if e.Envelope.PayloadType == "" || e.Envelope.Payload == "" {
-		return nil, fmt.Errorf("PayloadType and Payload not populated correctly")
+		return fmt.Errorf("PayloadType and Payload not populated correctly")
 	}
 
-	s, err := cryptoutil.NewSigner(signer, opts...)
+	se, err := idsse.Sign(e.Envelope.PayloadType, []byte(e.Envelope.Payload), idsse.SignWithSigners(*signer))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	se, err := idsse.Sign(e.Envelope.PayloadType, []byte(e.Envelope.Payload), idsse.SignWithSigners(s))
-	if err != nil {
-		return nil, err
-	}
+	e.Envelope = &se
 
-	return se, nil
+	return nil
 }
 
-func (e *DSSEEnvelope) Verify(pub *crypto.PublicKey, opts ...cryptoutil.VerifierOption) (interface{}, error) {
-	v, err := cryptoutil.NewVerifier(pub, opts...)
+func (e *Envelope) Verify(v *cryptoutil.Verifier) error {
+	_, err := e.Envelope.Verify(idsse.VerifyWithVerifiers(*v))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	ve, err := e.Envelope.Verify(idsse.VerifyWithVerifiers(v))
-	if err != nil {
-		return nil, err
-	}
-
-	return ve, nil
+	return nil
 }
 
-func (e *DSSEEnvelope) Content() (interface{}, error)
+func (e *Envelope) Content() (*envelope.EnvelopeContent, error) {
+	env := envelope.EnvelopeContent{}
+	env.Payload = e.Envelope.Payload
+	env.PayloadType = e.Envelope.PayloadType
+	for _, sig := range e.Envelope.Signatures {
+		s := envelope.SignatureInfo{
+			KeyID:         sig.KeyID,
+			Signature:     sig.Signature,
+			Certificate:   sig.Certificate,
+			Intermediates: sig.Intermediates,
+		}
+
+		env.Signatures = append(env.Signatures, s)
+	}
+
+	return &env, nil
+}

--- a/signature/envelope/dsse/dsse.go
+++ b/signature/envelope/dsse/dsse.go
@@ -1,0 +1,42 @@
+package dsse
+
+import (
+	"crypto"
+	"fmt"
+
+	"github.com/in-toto/go-witness/cryptoutil"
+	idsse "github.com/in-toto/go-witness/dsse"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+)
+
+type DSSEEnvelope struct {
+	Envelope *dsse.Envelope
+}
+
+func (e *DSSEEnvelope) Sign(signer *crypto.Signer, opts ...cryptoutil.SignerOption) (interface{}, error) {
+	if e.Envelope.PayloadType == "" || e.Envelope.Payload == "" {
+		return nil, fmt.Errorf("PayloadType and Payload not populated correctly")
+	}
+
+	s, err := cryptoutil.NewSigner(signer)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := cryptoutil.NewVerifier(signer)
+	if err != nil {
+		return nil, err
+	}
+
+	sv := cryptoutil.SignerVerifier{
+		Signer:   s,
+		Verifier: v,
+	}
+
+	se, err := idsse.Sign(e.Envelope.PayloadType, []byte(e.Envelope.Payload), idsse.SignWithSigners(sv.Signer))
+	if err != nil {
+		return nil, err
+	}
+
+	return se, nil
+}

--- a/signature/envelope/dsse/dsse.go
+++ b/signature/envelope/dsse/dsse.go
@@ -12,11 +12,13 @@ import (
 	idsse "github.com/in-toto/go-witness/dsse"
 )
 
+// Envelope is a wrapper around the DSSE envelope that implements the Envelope interface.
 type Envelope struct {
+	// Envelope is the DSSE envelope.
 	Envelope *idsse.Envelope
 }
 
-// NewEnvelope creates a new envelope from specified payload type and non-base64 encoded payload
+// NewEnvelope creates a new envelope from specified payload type and non-base64 encoded payload.
 func NewEnvelope(payloadType string, payload []byte) (*Envelope, error) {
 	// simple if statement to detect if payload is base64 encoded
 	if _, err := base64.StdEncoding.DecodeString(string(payload)); err == nil {
@@ -28,6 +30,7 @@ func NewEnvelope(payloadType string, payload []byte) (*Envelope, error) {
 	return &Envelope{Envelope: &e}, nil
 }
 
+// Sign signs the payload with the specified signer and options.
 func (e *Envelope) Sign(signer *cryptoutil.Signer, opts ...envelope.EnvelopeOption) error {
 	so := envelope.EnvelopeOptions{}
 
@@ -49,6 +52,7 @@ func (e *Envelope) Sign(signer *cryptoutil.Signer, opts ...envelope.EnvelopeOpti
 	return nil
 }
 
+// Verify verifies the envelope against the public key verifier in the input.
 func (e *Envelope) Verify(v *cryptoutil.Verifier) error {
 	_, err := e.Envelope.Verify(idsse.VerifyWithVerifiers(*v))
 	if err != nil {
@@ -58,6 +62,7 @@ func (e *Envelope) Verify(v *cryptoutil.Verifier) error {
 	return nil
 }
 
+// Content returns the envelope content for use in other operations.
 func (e *Envelope) Content() (*envelope.EnvelopeContent, error) {
 	env := envelope.EnvelopeContent{}
 	env.Payload = e.Envelope.Payload

--- a/signature/envelope/envelope.go
+++ b/signature/envelope/envelope.go
@@ -17,5 +17,18 @@ type Envelope interface {
 
 	// Content returns the payload and signer information of the envelope.
 	// Content is trusted only after the successful call to `Verify()`.
-	Content() ([]byte, error)
+	Content() (EnvelopeContent, error)
+}
+
+type EnvelopeContent struct {
+	PayloadType string
+	Payload     string
+	Signatures  []SignatureInfo
+}
+
+type SignatureInfo struct {
+	// NOTE: Made this a string for now but I think it might be better in antother form later
+	SignatureAlgorithm string
+
+	Signature []byte
 }

--- a/signature/envelope/envelope.go
+++ b/signature/envelope/envelope.go
@@ -2,15 +2,15 @@ package envelope
 
 import (
 	"github.com/in-toto/go-witness/cryptoutil"
+	idsse "github.com/in-toto/go-witness/dsse"
 )
 
 // Envelope provides basic functions to manipulate signatures.
 type Envelope interface {
-	// Sign generates and sign the envelope according to the sign request.
-	Sign(signer *cryptoutil.Signer) error
+	// Sign signs the pre-generated envelope with relevant fields already populated.
+	Sign(signer *cryptoutil.Signer, opts ...EnvelopeOption) error
 
-	// Verify verifies the envelope and returns its enclosed payload and signer
-	// info.
+	// Verify verifies the envelope.
 	Verify(pub *cryptoutil.Verifier) error
 
 	// Content returns the payload and signer information of the envelope.
@@ -29,4 +29,16 @@ type SignatureInfo struct {
 	Signature     []byte   `json:"sig"`
 	Certificate   []byte   `json:"certificate,omitempty"`
 	Intermediates [][]byte `json:"intermediates,omitempty"`
+}
+
+type EnvelopeOptions struct {
+	Timestampers []idsse.Timestamper
+}
+
+type EnvelopeOption func(ro *EnvelopeOptions)
+
+func WithTimestampers(timestampers []idsse.Timestamper) EnvelopeOption {
+	return func(eo *EnvelopeOptions) {
+		eo.Timestampers = timestampers
+	}
 }

--- a/signature/envelope/envelope.go
+++ b/signature/envelope/envelope.go
@@ -10,7 +10,7 @@ type Envelope interface {
 	// Sign signs the pre-generated envelope with relevant fields already populated.
 	Sign(signer *cryptoutil.Signer, opts ...EnvelopeOption) error
 
-	// Verify verifies the envelope.
+	// Verify verifies the envelope against the public key verifier in the input.
 	Verify(pub *cryptoutil.Verifier) error
 
 	// Content returns the payload and signer information of the envelope.
@@ -18,25 +18,44 @@ type Envelope interface {
 	Content() (*EnvelopeContent, error)
 }
 
+// EnvelopeContent holds contents of the envelope for the purpose reuse in other operations.
 type EnvelopeContent struct {
+	// Payload Type is a string that uniquely and unambiguously identifies how to interpret the payload.
 	PayloadType string
-	Payload     string
-	Signatures  []SignatureInfo
+	// Payload is the base64 encoded data that is signed.
+	Payload string
+	// Signatures is a list of signatures that were generated against the payload.
+	Signatures []SignatureInfo
 }
 
+// SignatureInfo holds the signature itself, as well as any other information that may be needed in other operations.
 type SignatureInfo struct {
-	KeyID         string   `json:"keyid"`
-	Signature     []byte   `json:"sig"`
-	Certificate   []byte   `json:"certificate,omitempty"`
+	// KeyID is the indentifier of the key that was used to sign the payload (sha256 hash of the public key).
+	KeyID string `json:"keyid"`
+
+	// Signature is the signature that was generated against the payload.
+	Signature []byte `json:"sig"`
+
+	// Certificate is the leaf certificate of the signing key.
+	Certificate []byte `json:"certificate,omitempty"`
+
+	// Root is the root certificate that signed the leaf and Intermediate certificates.
+	Root [][]byte
+
+	// Intermediates is the list of intermediate certificates that are associated with the signing key.
 	Intermediates [][]byte `json:"intermediates,omitempty"`
 }
 
+// EnvelopeOptions holds the options that can be passed to the Envelope.Sign() function.
 type EnvelopeOptions struct {
+	// Timestampers is a list of the timestamp authorities that will be used to timestamp the payload.
 	Timestampers []idsse.Timestamper
 }
 
+// EnvelopeOption defines a function that can be used as an input to Envelope.Sign() for the purpose of passing in options.
 type EnvelopeOption func(ro *EnvelopeOptions)
 
+// WithTimestampers returns an EnvelopeOption that will set the timestampers field of the EnvelopeOptions.
 func WithTimestampers(timestampers []idsse.Timestamper) EnvelopeOption {
 	return func(eo *EnvelopeOptions) {
 		eo.Timestampers = timestampers

--- a/signature/envelope/envelope.go
+++ b/signature/envelope/envelope.go
@@ -1,23 +1,21 @@
 package envelope
 
 import (
-	"crypto"
-
 	"github.com/in-toto/go-witness/cryptoutil"
 )
 
 // Envelope provides basic functions to manipulate signatures.
 type Envelope interface {
 	// Sign generates and sign the envelope according to the sign request.
-	Sign(signer *crypto.Signer, opts ...cryptoutil.SignerOption) (interface{}, error)
+	Sign(signer *cryptoutil.Signer) error
 
 	// Verify verifies the envelope and returns its enclosed payload and signer
 	// info.
-	Verify(pub *crypto.PublicKey, opts ...cryptoutil.VerifierOption) (interface{}, error)
+	Verify(pub *cryptoutil.Verifier) error
 
 	// Content returns the payload and signer information of the envelope.
 	// Content is trusted only after the successful call to `Verify()`.
-	Content() (EnvelopeContent, error)
+	Content() (*EnvelopeContent, error)
 }
 
 type EnvelopeContent struct {
@@ -27,8 +25,8 @@ type EnvelopeContent struct {
 }
 
 type SignatureInfo struct {
-	// NOTE: Made this a string for now but I think it might be better in antother form later
-	SignatureAlgorithm string
-
-	Signature []byte
+	KeyID         string   `json:"keyid"`
+	Signature     []byte   `json:"sig"`
+	Certificate   []byte   `json:"certificate,omitempty"`
+	Intermediates [][]byte `json:"intermediates,omitempty"`
 }

--- a/signature/envelope/envelope.go
+++ b/signature/envelope/envelope.go
@@ -1,0 +1,21 @@
+package envelope
+
+import (
+	"crypto"
+
+	"github.com/in-toto/go-witness/cryptoutil"
+)
+
+// Envelope provides basic functions to manipulate signatures.
+type Envelope interface {
+	// Sign generates and sign the envelope according to the sign request.
+	Sign(signer *crypto.Signer, opts ...cryptoutil.SignerOption) (interface{}, error)
+
+	// Verify verifies the envelope and returns its enclosed payload and signer
+	// info.
+	Verify(pub *crypto.PublicKey, opts ...cryptoutil.VerifierOption) (interface{}, error)
+
+	// Content returns the payload and signer information of the envelope.
+	// Content is trusted only after the successful call to `Verify()`.
+	Content() ([]byte, error)
+}

--- a/source/source.go
+++ b/source/source.go
@@ -36,7 +36,7 @@ type Sourcer interface {
 
 func envelopeToCollectionEnvelope(reference string, env dsse.Envelope) (CollectionEnvelope, error) {
 	statement := intoto.Statement{}
-	if err := json.Unmarshal(env.Payload, &statement); err != nil {
+	if err := json.Unmarshal([]byte(env.Payload), &statement); err != nil {
 		return CollectionEnvelope{}, err
 	}
 

--- a/verify.go
+++ b/verify.go
@@ -81,7 +81,7 @@ func Verify(ctx context.Context, policyEnvelope dsse.Envelope, policyVerifiers [
 	}
 
 	pol := policy.Policy{}
-	if err := json.Unmarshal(vo.policyEnvelope.Payload, &pol); err != nil {
+	if err := json.Unmarshal([]byte(vo.policyEnvelope.Payload), &pol); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal policy from envelope: %w", err)
 	}
 


### PR DESCRIPTION
This is a draft for now so people can see my progress.

I am trying to refactor the `dsse` and `cryptoutil` parts of the repo so they can be:
a) set up for the expansion to more envelope types to sign and verify
b) make the current internal `dsse` library more streamlined with https://github.com/secure-systems-lab/go-securesystemslib. While we don't use it right now, we plan on migrating to it when it supports timestamps and intermediates (I think this PR might be related https://github.com/secure-systems-lab/dsse/pull/61).