### PR TITLE
Adding support for using timestamp authority and CA certificates for verifying policy

### DIFF
--- a/dsse/dsse.go
+++ b/dsse/dsse.go
@@ -32,11 +32,11 @@ func (e ErrNoMatchingSigs) Error() string {
 
 type ErrThresholdNotMet struct {
 	Theshold int
-	Acutal   int
+	Actual   int
 }
 
 func (e ErrThresholdNotMet) Error() string {
-	return fmt.Sprintf("envelope did not meet verifier threshold. expected %v valid verifiers but got %v", e.Theshold, e.Acutal)
+	return fmt.Sprintf("envelope did not meet verifier threshold. expected %v valid verifiers but got %v", e.Theshold, e.Actual)
 }
 
 type ErrInvalidThreshold int

--- a/dsse/dsse_test.go
+++ b/dsse/dsse_test.go
@@ -217,7 +217,7 @@ func TestThreshold(t *testing.T) {
 	assert.ElementsMatch(t, approvedVerifiers, expectedVerifiers)
 
 	approvedVerifiers, err = env.Verify(VerifyWithVerifiers(verifiers...), VerifyWithThreshold(10))
-	require.ErrorIs(t, err, ErrThresholdNotMet{Acutal: 5, Theshold: 10})
+	require.ErrorIs(t, err, ErrThresholdNotMet{Actual: 5, Theshold: 10})
 	assert.ElementsMatch(t, approvedVerifiers, expectedVerifiers)
 
 	_, err = env.Verify(VerifyWithVerifiers(verifiers...), VerifyWithThreshold(-10))

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/log"
 )
 
 type TimestampVerifier interface {
@@ -115,6 +116,8 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]PassedVerifier, error) {
 				if verifier, err := verifyX509Time(cert, sigIntermediates, options.roots, pae, sig.Signature, time.Now()); err == nil {
 					matchingSigFound = true
 					passedVerifiers = append(passedVerifiers, PassedVerifier{Verifier: verifier})
+				} else {
+					log.Debugf("failed to verify with timestamp verifier: %w", err)
 				}
 			} else {
 				var passedVerifier cryptoutil.Verifier
@@ -130,7 +133,10 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]PassedVerifier, error) {
 						if verifier, err := verifyX509Time(cert, sigIntermediates, options.roots, pae, sig.Signature, timestamp); err == nil {
 							passedVerifier = verifier
 							passedTimestampVerifiers = append(passedTimestampVerifiers, timestampVerifier)
+						} else {
+							log.Debugf("failed to verify with timestamp verifier: %w", err)
 						}
+
 					}
 				}
 
@@ -159,7 +165,7 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]PassedVerifier, error) {
 	}
 
 	if len(passedVerifiers) < options.threshold {
-		return passedVerifiers, ErrThresholdNotMet{Theshold: options.threshold, Acutal: len(passedVerifiers)}
+		return passedVerifiers, ErrThresholdNotMet{Theshold: options.threshold, Actual: len(passedVerifiers)}
 	}
 
 	return passedVerifiers, nil


### PR DESCRIPTION
After discovering that the `policy-ca` flag in `github.com/in-toto/witness` was not wired up correctly, I noticed that some change was required in go-witness to feed it into the verification function for the policy DSSE envelope. I also noticed that there was no way of specifying a timestamp authority CA certificate for the policy. Given that `Sign` supports specifying said timestamp authority, it seemed clear that adding support in Verify would be worthwhile.

Note that currently, the way that we are verifying the policy is different from how we verify attestations. It seems that said disparity does not need to be there and I will therefore create another Issue to track the need to refactor this. 

See Github issue here: https://github.com/in-toto/go-witness/issues/125