### PR TITLE
Adding support for supplying POM on Maven Attestor

### DIFF
--- a/attestation/maven/maven.go
+++ b/attestation/maven/maven.go
@@ -24,12 +24,14 @@ import (
 	"github.com/in-toto/go-witness/attestation"
 	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/in-toto/go-witness/log"
+	"github.com/in-toto/go-witness/registry"
 )
 
 const (
-	Name    = "maven"
-	Type    = "https://witness.dev/attestations/maven/v0.1"
-	RunType = attestation.PreMaterialRunType
+	Name           = "maven"
+	Type           = "https://witness.dev/attestations/maven/v0.1"
+	RunType        = attestation.PreMaterialRunType
+	defaultPomPath = "pom.xml"
 )
 
 // This is a hacky way to create a compile time error in case the attestor
@@ -42,7 +44,22 @@ var (
 func init() {
 	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
 		return New()
-	})
+	},
+		registry.StringConfigOption(
+			"pom-path",
+			fmt.Sprintf("The path to the Project Object Model (POM) XML file used for task being attested (default \"%s\").", defaultPomPath),
+			defaultPomPath,
+			func(a attestation.Attestor, pomPath string) (attestation.Attestor, error) {
+				mavAttestor, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("unexpected attestor type: %T is not a maven attestor", a)
+				}
+
+				WithPom(pomPath)(mavAttestor)
+				return mavAttestor, nil
+			},
+		),
+	)
 }
 
 type Attestor struct {
@@ -73,7 +90,7 @@ func WithPom(path string) Option {
 
 func New(opts ...Option) *Attestor {
 	attestor := &Attestor{
-		pomPath: "pom.xml",
+		pomPath: defaultPomPath,
 	}
 
 	for _, opt := range opts {

--- a/attestation/maven/maven_test.go
+++ b/attestation/maven/maven_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 
 	"github.com/in-toto/go-witness/attestation"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func writeTempPomXml(t *testing.T) (string, error) {
+func writeTempPomXml(t *testing.T, path string) (string, error) {
 	tmpDir := t.TempDir()
-	pomPath := filepath.Join(tmpDir, "pom.xml")
+	pomPath := filepath.Join(tmpDir, path)
 	file, err := os.Create(pomPath)
 	if err != nil {
 		return "", err
@@ -41,13 +40,39 @@ func writeTempPomXml(t *testing.T) (string, error) {
 }
 
 func TestMaven(t *testing.T) {
-	pomPath, err := writeTempPomXml(t)
-	require.NoError(t, err)
-	attestor := New(WithPom(pomPath))
-	ctx, err := attestation.NewContext([]attestation.Attestor{attestor})
-	require.NoError(t, err)
-	err = attestor.Attest(ctx)
-	assert.NoError(t, err)
+	workingDir := t.TempDir()
+
+	tests := []struct {
+		name    string
+		pomPath string
+	}{
+		{"no pom specified", ""},
+		{"regular pom with custom name", "custom-pom.xml"},
+		{"effective pom", "effective-pom.xml"},
+	}
+
+	for _, test := range tests {
+		var p string
+		var err error
+		if test.pomPath != "" {
+			p, err = writeTempPomXml(t, test.pomPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			p, err = writeTempPomXml(t, "pom.xml")
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		t.Run(test.name, func(t *testing.T) {
+			ctx, err := attestation.NewContext([]attestation.Attestor{}, attestation.WithWorkingDir(workingDir))
+			require.NoError(t, err)
+			a := New(WithPom(p))
+			require.NoError(t, a.Attest(ctx))
+		})
+	}
 }
 
 const testPomXml = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Reopened version of https://github.com/in-toto/go-witness/pull/100.