### PR TITLE
RunAttestors refactor

### DIFF
--- a/attestation/context.go
+++ b/attestation/context.go
@@ -125,6 +125,8 @@ func (ctx *AttestationContext) RunAttestors() error {
 				Reason: fmt.Sprintf("unknown run type %v", attestor.RunType()),
 			}
 		}
+
+		attestors[attestor.RunType()] = append(attestors[attestor.RunType()], attestor)
 	}
 
 	for _, atts := range attestors {

--- a/attestation/factory.go
+++ b/attestation/factory.go
@@ -41,6 +41,8 @@ type Subjecter interface {
 	Subjects() map[string]cryptoutil.DigestSet
 }
 
+// NOTE: not sure on the name of this interface, however I can't think of an alternative for now
+
 // Materialer allows attestors to communicate about materials that were observed
 // while the attestor executed. For example the material attestor records the hashes
 // of all files before a command is run.


### PR DESCRIPTION
Small work done to refactor the `RunAttestors()` function.

I have also made some changes to the `AttestationContext` functions, I am not quite sure why copies of the struct fields being returned need to be made. @mikhailswift I'll request your review to try and check that there isn't any extra context on this.