### PR TITLE
Checking policy signature against cert constraints

### DIFF
--- a/internal/test/util.go
+++ b/internal/test/util.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test
 
 import (

--- a/internal/test/util.go
+++ b/internal/test/util.go
@@ -1,0 +1,131 @@
+package test
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+
+	"github.com/in-toto/go-witness/cryptoutil"
+)
+
+func CreateRsaKey() (*rsa.PrivateKey, *rsa.PublicKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return priv, &priv.PublicKey, nil
+}
+
+func CreateTestKey() (cryptoutil.Signer, cryptoutil.Verifier, []byte, error) {
+	privKey, _, err := CreateRsaKey()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	signer := cryptoutil.NewRSASigner(privKey, crypto.SHA256)
+	verifier := cryptoutil.NewRSAVerifier(&privKey.PublicKey, crypto.SHA256)
+	keyBytes, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: keyBytes})
+
+	return signer, verifier, pemBytes, nil
+}
+
+func CreateCert(priv, pub interface{}, temp, parent *x509.Certificate) (*x509.Certificate, error) {
+	var err error
+	temp.SerialNumber, err = rand.Int(rand.Reader, big.NewInt(4294967295))
+	if err != nil {
+		return nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, temp, parent, pub, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	return x509.ParseCertificate(certBytes)
+}
+
+func CreateRoot() (*x509.Certificate, interface{}, error) {
+	priv, pub, err := CreateRsaKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		DNSNames: []string{"in-toto.io"},
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Organization: []string{"in-toto"},
+			CommonName:   "Test Root",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        false,
+		MaxPathLen:            2,
+	}
+
+	cert, err := CreateCert(priv, pub, template, template)
+	return cert, priv, err
+}
+
+func CreateIntermediate(parent *x509.Certificate, parentPriv interface{}) (*x509.Certificate, interface{}, error) {
+	priv, pub, err := CreateRsaKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Organization: []string{"TestifySec"},
+			CommonName:   "Test Intermediate",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		MaxPathLenZero:        false,
+		MaxPathLen:            1,
+	}
+
+	cert, err := CreateCert(parentPriv, pub, template, parent)
+	return cert, priv, err
+}
+
+func CreateLeaf(parent *x509.Certificate, parentPriv interface{}) (*x509.Certificate, interface{}, error) {
+	priv, pub, err := CreateRsaKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := &x509.Certificate{
+		DNSNames: []string{"in-toto.io"},
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Organization: []string{"In-toto"},
+			CommonName:   "Test Leaf",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+
+	cert, err := CreateCert(parentPriv, pub, template, parent)
+	return cert, priv, err
+}

--- a/policy/constraints.go
+++ b/policy/constraints.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 
 	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/log"
 )
 
 const (
@@ -38,6 +39,10 @@ type CertConstraint struct {
 func (cc CertConstraint) Check(verifier *cryptoutil.X509Verifier, trustBundles map[string]TrustBundle) error {
 	errs := make([]error, 0)
 	cert := verifier.Certificate()
+
+	if cc.DNSNames[0] == "*" && cc.Emails[0] == "*" && cc.Organizations[0] == "*" && cc.URIs[0] == "*" && cc.Roots[0] == "*" && cc.CommonName == "*" {
+		log.Warn("A certificate is being validated without any constraints set. Any certificate in the trust bundle will pass")
+	}
 
 	if err := checkCertConstraint("common name", []string{cc.CommonName}, []string{cert.Subject.CommonName}); err != nil {
 		errs = append(errs, err)

--- a/policy/constraints.go
+++ b/policy/constraints.go
@@ -19,7 +19,6 @@ import (
 	"net/url"
 
 	"github.com/in-toto/go-witness/cryptoutil"
-	"github.com/in-toto/go-witness/log"
 )
 
 const (
@@ -39,10 +38,6 @@ type CertConstraint struct {
 func (cc CertConstraint) Check(verifier *cryptoutil.X509Verifier, trustBundles map[string]TrustBundle) error {
 	errs := make([]error, 0)
 	cert := verifier.Certificate()
-
-	if cc.DNSNames[0] == "*" && cc.Emails[0] == "*" && cc.Organizations[0] == "*" && cc.URIs[0] == "*" && cc.Roots[0] == "*" && cc.CommonName == "*" {
-		log.Warn("A certificate is being validated without any constraints set. Any certificate in the trust bundle will pass")
-	}
 
 	if err := checkCertConstraint("common name", []string{cc.CommonName}, []string{cert.Subject.CommonName}); err != nil {
 		errs = append(errs, err)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -236,35 +236,13 @@ func (step Step) checkFunctionaries(verifiedStatements []source.VerifiedCollecti
 		}
 
 		for _, verifier := range verifiedStatement.Verifiers {
-			verifierID, err := verifier.KeyID()
-			if err != nil {
-				log.Debugf("(policy) skipping verifier: could not get key id: %w", err)
-				continue
-			}
-
 			for _, functionary := range step.Functionaries {
-				if functionary.PublicKeyID != "" && functionary.PublicKeyID == verifierID {
+				if err := functionary.Validate(verifier, trustBundles); err != nil {
+					log.Debugf("(policy) skipping verifier: %w", err)
+					continue
+				} else {
 					collections = append(collections, verifiedStatement)
-					break
 				}
-
-				x509Verifier, ok := verifier.(*cryptoutil.X509Verifier)
-				if !ok {
-					log.Debugf("(policy) skipping verifier: verifier with ID %v is not a public key verifier or a x509 verifier", verifierID)
-					continue
-				}
-
-				if len(functionary.CertConstraint.Roots) == 0 {
-					log.Debugf("(policy) skipping verifier: verifier with ID %v is an x509 verifier, but step %v does not have any truested roots", verifierID, step)
-					continue
-				}
-
-				if err := functionary.CertConstraint.Check(x509Verifier, trustBundles); err != nil {
-					log.Debugf("(policy) skipping verifier: verifier with ID %v doesn't meet certificate constraint: %w", verifierID, err)
-					continue
-				}
-
-				collections = append(collections, verifiedStatement)
 			}
 		}
 	}

--- a/verify.go
+++ b/verify.go
@@ -106,8 +106,13 @@ func VerifyWithPolicyCertConstraints(commonName string, dnsNames []string, email
 // if verifiation is successful.
 func Verify(ctx context.Context, policyEnvelope dsse.Envelope, policyVerifiers []cryptoutil.Verifier, opts ...VerifyOption) (map[string][]source.VerifiedCollection, error) {
 	vo := verifyOptions{
-		policyEnvelope:  policyEnvelope,
-		policyVerifiers: policyVerifiers,
+		policyEnvelope:      policyEnvelope,
+		policyVerifiers:     policyVerifiers,
+		policyCommonName:    "*",
+		policyDNSNames:      []string{"*"},
+		policyOrganizations: []string{"*"},
+		policyURIs:          []string{"*"},
+		policyEmails:        []string{"*"},
 	}
 
 	for _, opt := range opts {
@@ -210,6 +215,7 @@ func verifyPolicySignature(ctx context.Context, vo verifyOptions) error {
 					DNSNames:      vo.policyDNSNames,
 				},
 			}
+
 		} else {
 			f = policy.Functionary{
 				Type:        "key",
@@ -220,6 +226,7 @@ func verifyPolicySignature(ctx context.Context, vo verifyOptions) error {
 		err = f.Validate(verifier.Verifier, trustBundle)
 		if err != nil {
 			log.Debugf("Policy Verifier %s failed failed to match supplied constraints: %w, continuing...", kid, err)
+			fmt.Println("FAILED: ", err.Error())
 			continue
 		}
 		passed = true

--- a/verify.go
+++ b/verify.go
@@ -226,7 +226,6 @@ func verifyPolicySignature(ctx context.Context, vo verifyOptions) error {
 		err = f.Validate(verifier.Verifier, trustBundle)
 		if err != nil {
 			log.Debugf("Policy Verifier %s failed failed to match supplied constraints: %w, continuing...", kid, err)
-			fmt.Println("FAILED: ", err.Error())
 			continue
 		}
 		passed = true

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,140 @@
+package witness
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/dsse"
+	"github.com/in-toto/go-witness/internal/test"
+	"github.com/in-toto/go-witness/intoto"
+	"github.com/in-toto/go-witness/timestamp"
+)
+
+func TestVerifyPolicySignature(t *testing.T) {
+	// we dont care about the content of th envelope for this test
+	rsaSigner, rsaVerifier, _, err := test.CreateTestKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badRootCert, _, err := test.CreateRoot()
+	rootCert, key, err := test.CreateRoot()
+	leafCert, leafPriv, err := test.CreateLeaf(rootCert, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	x509Signer, err := cryptoutil.NewSigner(leafPriv, cryptoutil.SignWithCertificate(leafCert))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timestampers := []timestamp.FakeTimestamper{
+		{T: time.Now()},
+		{T: time.Now().Add(12 * time.Hour)},
+	}
+
+	// Define the test cases.
+	tests := []struct {
+		name            string
+		signer          cryptoutil.Signer
+		verifier        cryptoutil.Verifier
+		timestampers    []timestamp.FakeTimestamper
+		Roots           []*x509.Certificate
+		Intermediates   []*x509.Certificate
+		certConstraints VerifyOption
+		wantErr         bool
+	}{
+		{
+			name:     "valid rsa signature",
+			signer:   rsaSigner,
+			verifier: rsaVerifier,
+			// passing in timestampers to ensure that it is ignored
+			timestampers: timestampers,
+			wantErr:      false,
+		},
+		{
+			name:    "invalid rsa signature",
+			signer:  rsaSigner,
+			Roots:   []*x509.Certificate{rootCert},
+			wantErr: true,
+		},
+		{
+			name:   "valid x509 signature",
+			signer: x509Signer,
+			// We're going to pass in to ensure that it is ignored
+			Roots:   []*x509.Certificate{rootCert},
+			wantErr: false,
+		},
+		{
+			name:   "valid x509 signature w/ constraints",
+			signer: x509Signer,
+			// We're going to pass in to ensure that it is ignored
+			Roots:           []*x509.Certificate{rootCert},
+			certConstraints: VerifyWithPolicyCertConstraints(leafCert.Subject.CommonName, leafCert.DNSNames, []string{"*"}, []string{"*"}, []string{"*"}),
+			timestampers:    timestampers,
+			wantErr:         false,
+		},
+		{
+			name:   "valid x509 signature w/ bad constraints",
+			signer: x509Signer,
+			// We're going to pass in to ensure that it is ignored
+			Roots:           []*x509.Certificate{rootCert},
+			certConstraints: VerifyWithPolicyCertConstraints("foo", []string{"bar"}, []string{"baz"}, []string{"qux"}, []string{"quux"}),
+			wantErr:         true,
+		},
+		{
+			name:   "unknown root",
+			signer: x509Signer,
+			// We're going to pass in to ensure that it is ignored
+			Roots:   []*x509.Certificate{badRootCert},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		var ts []timestamp.Timestamper
+		for _, t := range tt.timestampers {
+			ts = append(ts, t)
+		}
+
+		env, err := dsse.Sign(intoto.PayloadType, bytes.NewReader([]byte("this is some test data")), dsse.SignWithTimestampers(ts...), dsse.SignWithSigners(tt.signer))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var tv []timestamp.TimestampVerifier
+		for _, t := range tt.timestampers {
+			tv = append(tv, t)
+		}
+
+		vo := verifyOptions{
+			policyEnvelope:             env,
+			policyVerifiers:            []cryptoutil.Verifier{tt.verifier},
+			policyCARoots:              tt.Roots,
+			policyTimestampAuthorities: tv,
+			policyCommonName:           "*",
+			policyDNSNames:             []string{"*"},
+			policyOrganizations:        []string{"*"},
+			policyURIs:                 []string{"*"},
+			policyEmails:               []string{"*"},
+		}
+
+		if tt.certConstraints != nil {
+			tt.certConstraints(&vo)
+		}
+
+		err = verifyPolicySignature(context.TODO(), vo)
+		if err != nil && !tt.wantErr {
+			t.Errorf("testName = %s, error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		} else {
+			fmt.Printf("test %s passed\n", tt.name)
+		}
+
+	}
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package witness
 
 import (
@@ -23,7 +37,15 @@ func TestVerifyPolicySignature(t *testing.T) {
 	}
 
 	badRootCert, _, err := test.CreateRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	rootCert, key, err := test.CreateRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	leafCert, leafPriv, err := test.CreateLeaf(rootCert, key)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR makes it possible to inspect the certificate attached to the signature (in the case that it was signed with x509 certificate) against user supplied cert constraints.

It should be noted that the constraint checks we perform is against *any* verifier that passes the initial policy verification logic. I am not sure whether this is an issue, but it is still something to be aware of. see [here](https://github.com/in-toto/go-witness/compare/main...ChaosInTheCRD:checking-policy-against-cert-constraints?expand=1#diff-32870c78c32d49e31ad4f22eaeac957ae6b988eea6fc937c9dba68035ac0d1b6R202-R212).

Another thing to note is that currently this logic has been broken out into a `verifyPolicySignature` function underneath the main `Verify` function. There may be a good place in the library to put this, but I couldn't think of one while working on it. Any suggestions on where we should put this would be most welcome.

