### PR TITLE
Adding workaround due to failing workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,3 +43,4 @@ jobs:
         with:
           version: latest
           args: --timeout=3m
+          skip-pkg-cache: true


### PR DESCRIPTION
For reasons that I can't quite pinpoint, https://github.com/in-toto/go-witness/pull/131's golangci-lint workflow is failing repeatedly.

I am unable to reproduce this locally, but it is clear that [this issue is occurring elsewhere](https://github.com/golangci/golangci-lint-action/issues/244), with projects such as [https://github.com/prometheus-operator/prometheus-operator/pull/6221](prometheus-operator) and [https://github.com/kumahq/kuma/pull/8820](kuma) opting to add the workaround in this PR. This seems like the correct change to minimise time lost investigating this issue.

It doesn't seem like there will be a lot of time lost in the workflows by skipping pkg cache, and if approved i'll also add a PR in https://github.com/in-toto/witness and https://github.com/in-toto/archivista to prevent issues in said respective repositories.