### PR TITLE
fixing error in github actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       artifact-upload-path: profile.cov
 
   release:
-    needs: [fmt, sast, unit-tests]
+    needs: [fmt, sast, unit-test]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The release action introduced in a previous PR is broken due to a small typo. This fixes it.