### PR TITLE
fix: vault warnings are an array, not a string

### DIFF
--- a/signer/vault/request.go
+++ b/signer/vault/request.go
@@ -48,7 +48,7 @@ type issueResponse struct {
 	LeaseID       string            `json:"lease_id"`
 	Renewable     bool              `json:"renewable"`
 	LeaseDuration int               `json:"lease_duration"`
-	Warnings      string            `json:"warnings"`
+	Warnings      []string          `json:"warnings"`
 	Data          issueResponseData `json:"data"`
 }
 


### PR DESCRIPTION
A user encountered an issue while using witness with the vault pki signer.

```
msg="failed to create vault signer: failed to issue certificate: json: cannot unmarshal array into Go struct field issueResponse.warnings of type string"
level=error msg="failed to load signers"
```

It turns out warnings is intended to be an array of strings, as indicated by hashicorp's own client lib: 
https://github.com/hashicorp/vault-client-go/blob/cfdcbeda2e34770a045cc9f71ad25db195e97181/response.go#L31

However, their documentation seems inaccurate and represents this as a string:
https://developer.hashicorp.com/vault/api-docs/secret/pki#sample-response-6

Confirmed that this change fixes the user's error.