### PR TITLE
fix: reset verifier each iteration while loading pub keys from policy

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -25,8 +25,10 @@ import (
 	_ "github.com/in-toto/go-witness/attestation/github"
 	_ "github.com/in-toto/go-witness/attestation/gitlab"
 	_ "github.com/in-toto/go-witness/attestation/jwt"
+	_ "github.com/in-toto/go-witness/attestation/material"
 	_ "github.com/in-toto/go-witness/attestation/maven"
 	_ "github.com/in-toto/go-witness/attestation/oci"
+	_ "github.com/in-toto/go-witness/attestation/product"
 	_ "github.com/in-toto/go-witness/attestation/sarif"
 
 	// signer providers

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -57,10 +57,10 @@ type PublicKey struct {
 // PublicKeyVerifiers returns verifiers for each of the policy's embedded public keys grouped by the key's ID
 func (p Policy) PublicKeyVerifiers() (map[string]cryptoutil.Verifier, error) {
 	verifiers := make(map[string]cryptoutil.Verifier)
-	var verifier cryptoutil.Verifier
 	var err error
 
 	for _, key := range p.PublicKeys {
+		var verifier cryptoutil.Verifier
 		for _, prefix := range kms.SupportedProviders() {
 			if strings.HasPrefix(key.KeyID, prefix) {
 				verifier, err = kms.New(kms.WithRef(key.KeyID), kms.WithHash("SHA256")).Verifier(context.TODO())


### PR DESCRIPTION
Ran into an issue testing a policy with multiple public key functionaries. I would continually get ErrKeyIDMismatch when loading the second key. Turns out the verifier variable was being persisted on each iteration and failing the nil check to reload the new verifier. Resetting this within the for loop fixes it.