### PR TITLE
feat: Add field `name` in the Policy

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Witness Contributors
+// Copyright 2021-2024 The Witness Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ const PolicyPredicate = "https://witness.testifysec.com/policy/v0.1"
 // +kubebuilder:object:generate=true
 type Policy struct {
 	Expires              metav1.Time          `json:"expires"`
+	Name                 string               `json:"name,omitempty"`
 	Roots                map[string]Root      `json:"roots,omitempty"`
 	TimestampAuthorities map[string]Root      `json:"timestampauthorities,omitempty"`
 	PublicKeys           map[string]PublicKey `json:"publickeys,omitempty"`

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Witness Contributors
+// Copyright 2021-2024 The Witness Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ deny[msg] {
 				Key:   pubKeyPem2,
 			},
 		},
+		Name: "test-v1",
 		Steps: map[string]Step{
 			"step1": {
 				Name: "step1",


### PR DESCRIPTION
Includes the field `name` for the Policy as an optional. The `name` helps users define and identify a policy with a unique identifier, allowing even versioning.

Motivation:
It can be difficult to manage and identify multiple policies by a file name or its content, depending on the storage usage.
In automation, this field can also be helpful.