### PR TITLE
Adding functionality for dirhash in library

### DIFF
--- a/attestation/file/file_test.go
+++ b/attestation/file/file_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gobwas/glob"
 	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/stretchr/testify/require"
 )
@@ -38,13 +39,15 @@ func TestBrokenSymlink(t *testing.T) {
 	symTestDir := filepath.Join(dir, "symTestDir")
 	require.NoError(t, os.Symlink(testDir, symTestDir))
 
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{})
+	dirHash := make([]glob.Glob, 0)
+
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash)
 	require.NoError(t, err)
 
 	// remove the symlinks and make sure we don't get an error back
 	require.NoError(t, os.RemoveAll(testDir))
 	require.NoError(t, os.RemoveAll(testFile))
-	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{})
+	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash)
 	require.NoError(t, err)
 }
 
@@ -57,7 +60,40 @@ func TestSymlinkCycle(t *testing.T) {
 	symTestDir := filepath.Join(dir, "symTestDir")
 	require.NoError(t, os.Symlink(dir, symTestDir))
 
+	dirHash := make([]glob.Glob, 0)
+
 	// if a symlink cycle weren't properly handled this would be an infinite loop
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{})
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHash)
 	require.NoError(t, err)
+}
+
+func TestDirHash(t *testing.T) {
+	dir := t.TempDir()
+	testFile := filepath.Join(dir, "testfile")
+	require.NoError(t, os.WriteFile(testFile, []byte("some dummy data"), os.ModePerm))
+	testDir := filepath.Join(dir, "testdir")
+	require.NoError(t, os.Mkdir(testDir, os.ModePerm))
+	testFile2 := filepath.Join(testDir, "testfile2")
+	require.NoError(t, os.WriteFile(testFile2, []byte("more dummy data"), os.ModePerm))
+
+	dirHashGlobs := make([]glob.Glob, 0)
+
+	dirHash := "testdir"
+	dirHashGlobItem, _ := glob.Compile(dirHash)
+	dirHashGlobs = append(dirHashGlobs, dirHashGlobItem)
+
+	artifacts, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHashGlobs)
+	require.NoError(t, err)
+
+	// Below command is example usage on the above created scenario for testdir.
+	// find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum | sha256sum
+	dirHashSha256 := "ba9842eac063209c5f67c5a202b2b3a710f8f845f1d064f54af56763645b895b"
+
+	require.Len(t, artifacts, 2)
+
+	dirDigestSet := artifacts["testdir/"]
+	dirDigestSetMap, err := dirDigestSet.ToNameMap()
+	require.NoError(t, err)
+
+	require.Equal(t, dirDigestSetMap["dirHash"], dirHashSha256)
 }

--- a/attestation/link/link_test.go
+++ b/attestation/link/link_test.go
@@ -99,8 +99,8 @@ func TestAttest(t *testing.T) {
 	// Setup Materials
 	m := attestors.NewTestMaterialAttestor()
 	materials := make(map[string]cryptoutil.DigestSet)
-	materials["test2"] = cryptoutil.DigestSet{{Hash: crypto.SHA256, GitOID: false}: "a53d0741798b287c6dd7afa64aee473f305e65d3f49463bb9d7408ec3b12bf5f"}
-	materials["test1"] = cryptoutil.DigestSet{{Hash: crypto.SHA256, GitOID: false}: "a53d0741798b287c6dd7afa64aee473f305e65d3f49463bb9d7408ec3b12bf5f"}
+	materials["test2"] = cryptoutil.DigestSet{{Hash: crypto.SHA256, GitOID: false, DirHash: false}: "a53d0741798b287c6dd7afa64aee473f305e65d3f49463bb9d7408ec3b12bf5f"}
+	materials["test1"] = cryptoutil.DigestSet{{Hash: crypto.SHA256, GitOID: false, DirHash: false}: "a53d0741798b287c6dd7afa64aee473f305e65d3f49463bb9d7408ec3b12bf5f"}
 	m.SetMaterials(materials)
 
 	// Setup CommandRun

--- a/attestation/material/material.go
+++ b/attestation/material/material.go
@@ -90,7 +90,7 @@ func (a *Attestor) Schema() *jsonschema.Schema {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{}, false, map[string]bool{})
+	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{}, false, map[string]bool{}, ctx.DirHashGlob())
 	if err != nil {
 		return err
 	}

--- a/cryptoutil/dirhash.go
+++ b/cryptoutil/dirhash.go
@@ -1,0 +1,61 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// DirHashSha256 is the "h1:" directory hash function, using SHA-256.
+//
+// DirHashSha256 returns a SHA-256 hash of a summary
+// prepared as if by the Unix command:
+//
+//	sha256sum $(find . -type f | sort) | sha256sum
+//
+// More precisely, the hashed summary contains a single line for each file in the list,
+// ordered by sort.Strings applied to the file names, where each line consists of
+// the hexadecimal SHA-256 hash of the file content,
+// two spaces (U+0020), the file name, and a newline (U+000A).
+//
+// File names with newlines (U+000A) are disallowed.
+func DirhHashSha256(files []string, open func(string) (io.ReadCloser, error)) (string, error) {
+	h := sha256.New()
+	files = append([]string(nil), files...)
+	sort.Strings(files)
+	for _, file := range files {
+		if strings.Contains(file, "\n") {
+			return "", errors.New("dirhash: filenames with newlines are not supported")
+		}
+		r, err := open(file)
+		if err != nil {
+			return "", err
+		}
+		hf := sha256.New()
+		_, err = io.Copy(hf, r)
+		r.Close()
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintf(h, "%x  %s\n", hf.Sum(nil), file)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}


### PR DESCRIPTION
Related to: https://github.com/in-toto/witness/pull/436

This a different approach to #65. It captures a dirhash for material and product if the dir is mentioned as an argument.

```
witness run --dirhash-glob node_modules/* --step build -- npm clean-install
```

The argument can be repeated multiple time and globs with `**` are not allowed.

The output will generate a dirhash based on the algorithm use by golang in https://pkg.go.dev/golang.org/x/mod/sumdb/dirhash and is the same as described in the in-toto digest spec ([here](https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md#dirhash))

The subject for a dirhash will be `https://witness.dev/attestations/product/v0.1/dir:node_modules/example/`.

The policy works correctly and also `artifactsFrom` are correctly checked.

## Todo

- [x] allow verify to check not only file subject but also dir subject
- [x] decide on the copying of the glob library into the go-witness library.
- [x] discuss what additional docs on the library would be benificial