### PR TITLE
Allow certificate inspection on policy signature verification (including fulcio extensions)

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/in-toto/go-witness/log"
 	"github.com/in-toto/go-witness/policy"
 	"github.com/in-toto/go-witness/timestamp"
+	"github.com/sigstore/fulcio/pkg/certificate"
 )
 
 type VerifyPolicySignatureOptions struct {
@@ -37,6 +38,7 @@ type VerifyPolicySignatureOptions struct {
 	policyEmails               []string
 	policyOrganizations        []string
 	policyURIs                 []string
+	fulcioCertExtensions       certificate.Extensions
 }
 
 type Option func(*VerifyPolicySignatureOptions)
@@ -79,6 +81,12 @@ func NewVerifyPolicySignatureOptions(opts ...Option) *VerifyPolicySignatureOptio
 	}
 
 	return vo
+}
+
+func VerifyWithPolicyFulcioCertExtensions(extensions certificate.Extensions) Option {
+	return func(vo *VerifyPolicySignatureOptions) {
+		vo.fulcioCertExtensions = extensions
+	}
 }
 
 func VerifyWithPolicyCertConstraints(commonName string, dnsNames []string, emails []string, organizations []string, uris []string) Option {
@@ -125,6 +133,7 @@ func VerifyPolicySignature(ctx context.Context, envelope dsse.Envelope, vo *Veri
 					Emails:        vo.policyEmails,
 					Organizations: vo.policyOrganizations,
 					DNSNames:      vo.policyDNSNames,
+					Extensions:    vo.fulcioCertExtensions,
 				},
 			}
 

--- a/policy/constraints.go
+++ b/policy/constraints.go
@@ -110,7 +110,7 @@ func (cc CertConstraint) checkExtensions(ext []pkix.Extension) error {
 	for _, field := range fields {
 		constraintField := reflect.ValueOf(cc.Extensions).FieldByName(field.Name)
 		if constraintField.String() == "" {
-			log.Infof("No constraint for field %s, allowing all values", field.Name)
+			log.Debugf("No constraint for field %s, allowing all values", field.Name)
 			continue
 		}
 		extensionsField := reflect.ValueOf(extensions).FieldByName(field.Name)

--- a/run.go
+++ b/run.go
@@ -89,9 +89,12 @@ type RunResult struct {
 // Deprecated: Use RunWithExports instead
 func Run(stepName string, opts ...RunOption) (RunResult, error) {
 	results, err := run(stepName, opts)
-	if len(results) > 1 {
+	if len(results) == 0 {
+		return RunResult{}, err
+	} else if len(results) > 1 {
 		return RunResult{}, errors.New("expected a single result, got multiple")
 	}
+
 	return results[0], err
 }
 

--- a/verify.go
+++ b/verify.go
@@ -16,6 +16,7 @@ package witness
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,6 +29,8 @@ import (
 	"github.com/in-toto/go-witness/policy"
 	"github.com/in-toto/go-witness/slsa"
 	"github.com/in-toto/go-witness/source"
+	"github.com/in-toto/go-witness/timestamp"
+	"github.com/sigstore/fulcio/pkg/certificate"
 )
 
 func VerifySignature(r io.Reader, verifiers ...cryptoutil.Verifier) (dsse.Envelope, error) {
@@ -88,9 +91,33 @@ func VerifyWithRunOptions(opts ...RunOption) VerifyOption {
 	}
 }
 
+func VerifyWithPolicyFulcioCertExtensions(extensions certificate.Extensions) VerifyOption {
+	return func(vo *verifyOptions) {
+		vo.verifyPolicySignatureOptions = append(vo.verifyPolicySignatureOptions, ipolicy.VerifyWithPolicyFulcioCertExtensions(extensions))
+	}
+}
+
 func VerifyWithPolicyCertConstraints(commonName string, dnsNames []string, emails []string, organizations []string, uris []string) VerifyOption {
 	return func(vo *verifyOptions) {
 		vo.verifyPolicySignatureOptions = append(vo.verifyPolicySignatureOptions, ipolicy.VerifyWithPolicyCertConstraints(commonName, dnsNames, emails, organizations, uris))
+	}
+}
+
+func VerifyWithPolicyTimestampAuthorities(verifiers []timestamp.TimestampVerifier) VerifyOption {
+	return func(vo *verifyOptions) {
+		vo.verifyPolicySignatureOptions = append(vo.verifyPolicySignatureOptions, ipolicy.VerifyWithPolicyTimestampAuthorities(verifiers))
+	}
+}
+
+func VerifyWithPolicyCARoots(certs []*x509.Certificate) VerifyOption {
+	return func(vo *verifyOptions) {
+		vo.verifyPolicySignatureOptions = append(vo.verifyPolicySignatureOptions, ipolicy.VerifyWithPolicyCARoots(certs))
+	}
+}
+
+func VerifyWithPolicyCAIntermediates(certs []*x509.Certificate) VerifyOption {
+	return func(vo *verifyOptions) {
+		vo.verifyPolicySignatureOptions = append(vo.verifyPolicySignatureOptions, ipolicy.VerifyWithPolicyCAIntermediates(certs))
 	}
 }
 


### PR DESCRIPTION
These changes are necessary to fully enable https://github.com/in-toto/witness/pull/353 to work. Also note that this PR contains a fix for a panic in the case of a `[]RunResult` of length 0 (implying an error) getting returned from `Run`. 