### PR TITLE
BUG: `verifyX509Time` should return the verifier even if the verify fails (we want to get information about it later)

### DIFF
--- a/dsse/dsse.go
+++ b/dsse/dsse.go
@@ -36,7 +36,7 @@ func (e ErrNoMatchingSigs) Error() string {
 		if v.Error != nil {
 			kid, err := v.Verifier.KeyID()
 			if err != nil {
-				log.Warn("failed to get key id from verifier: %v", err)
+				log.Warnf("failed to get key id from verifier: %w", err)
 			}
 
 			s := fmt.Sprintf("  %s: %v\n", kid, v.Error)

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -197,9 +197,7 @@ func verifyX509Time(cert *x509.Certificate, sigIntermediates, roots []*x509.Cert
 		return nil, err
 	}
 
-	if err := verifier.Verify(bytes.NewReader(pae), sig); err != nil {
-		return nil, err
-	}
+	err = verifier.Verify(bytes.NewReader(pae), sig)
 
-	return verifier, nil
+	return verifier, err
 }


### PR DESCRIPTION
As the description says, we want the verifier back so we can present the verifier ID that introduced the error.