### PR TITLE
Fix releaser permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
     needs: [fmt, sast, unit-test]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for the action to work correctly
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # This is required for the action to work correctly
-      contents: read
+      contents: write # This is required for the action to work correctly
     steps:
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5


### PR DESCRIPTION
it seems like the releaser action needs write permissions? Seen in the documentation [here](https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions)