### PR TITLE
Step analyze fix

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -331,6 +331,7 @@ func (p Policy) verifyArtifacts(resultsByStep map[string]StepResult) (map[string
 				}
 
 				result.Rejected = append(result.Rejected, reject)
+				result.Passed = []source.CollectionVerificationResult{}
 				resultsByStep[step.Name] = result
 			}
 		}

--- a/policy/step.go
+++ b/policy/step.go
@@ -65,7 +65,7 @@ type StepResult struct {
 // in order to save the failure reasons so we can present them all at the end of the verification process.
 func (r StepResult) Analyze() bool {
 	var pass bool
-	if len(r.Passed) > 0 && len(r.Rejected) == 0 {
+	if len(r.Passed) > 0 {
 		pass = true
 	}
 


### PR DESCRIPTION
If any evidence exists that causes a step evaluation to fail, the entire policy will fail, even if there's passing evidence at another search depth. Also, results from the verifyArtifacts function are carrying forward passed results, even if the artifact comparison doesn't match.