### PR TITLE
Allow attestors to have multiple types

### DIFF
--- a/attestation/factory.go
+++ b/attestation/factory.go
@@ -90,6 +90,14 @@ func RegisterAttestation(name, predicateType string, run RunType, factoryFunc re
 	attestationsByRun[run] = registrationEntry
 }
 
+func RegisterAttestationWithTypes(name string, predicateTypes []string, run RunType, factoryFunc registry.FactoryFunc[Attestor], opts ...registry.Configurer) {
+	registrationEntry := attestorRegistry.Register(name, factoryFunc, opts...)
+	for _, predicateType := range predicateTypes {
+		attestationsByType[predicateType] = registrationEntry
+	}
+	attestationsByRun[run] = registrationEntry
+}
+
 func FactoryByType(uri string) (registry.FactoryFunc[Attestor], bool) {
 	registrationEntry, ok := attestationsByType[uri]
 	return registrationEntry.Factory, ok

--- a/attestation/sbom/sbom.go
+++ b/attestation/sbom/sbom.go
@@ -48,7 +48,7 @@ var (
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType,
+	attestation.RegisterAttestationWithTypes(Name, []string{Type, SPDXPredicateType, CycloneDxPredicateType}, RunType,
 		func() attestation.Attestor { return NewSBOMAttestor() },
 		registry.BoolConfigOption(
 			"export",


### PR DESCRIPTION
## What this PR does / why we need it

This will allow the SBOM attestor, and future attestors, to support multiple types for a single attestor. In the case of the SBOM attestor, we'd like to record the appropriate type for SPDX, CycloneDX, etc without having to implement a different attestor for the same functionality.

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
