### PR TITLE
fix: disable omnitrail attestor on windows

### DIFF
--- a/attestation/omnitrail/omnitrail.go
+++ b/attestation/omnitrail/omnitrail.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
+
 package omnitrail
 
 import (

--- a/imports.go
+++ b/imports.go
@@ -29,7 +29,6 @@ import (
 	_ "github.com/in-toto/go-witness/attestation/material"
 	_ "github.com/in-toto/go-witness/attestation/maven"
 	_ "github.com/in-toto/go-witness/attestation/oci"
-	_ "github.com/in-toto/go-witness/attestation/omnitrail"
 	_ "github.com/in-toto/go-witness/attestation/policyverify"
 	_ "github.com/in-toto/go-witness/attestation/product"
 	_ "github.com/in-toto/go-witness/attestation/sarif"

--- a/imports_nonwindows.go
+++ b/imports_nonwindows.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package witness
+
+// These imports will only be run when go-witness is built on a non-windows target OS
+import (
+	// all of the following imports are here so that each of the package's init functions run appropriately
+	_ "github.com/in-toto/go-witness/attestation/omnitrail"
+)


### PR DESCRIPTION
Currently omnitrail expects a POSIX filesystem, which windows does not supply. This causes windows builds to break when compiled with the omnitrail attestor. This PR adds a build flag to skip the omnitrail attestor when building for windows.

## What this PR does / why we need it

Description

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
