### PR TITLE
Define more than one `Type` per Attestor

### DIFF
--- a/attestation/aws-iid/aws-iid.go
+++ b/attestation/aws-iid/aws-iid.go
@@ -69,12 +69,13 @@ C1haGgSI/A1uZUKs/Zfnph0oEI0/hu1IIJ/SKBDtN5lvmZ/IzbOPIJWirlsllQIQ
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Attestor{}
-	_ attestation.Subjecter = &Attestor{}
+	_     attestation.Attestor  = &Attestor{}
+	_     attestation.Subjecter = &Attestor{}
+	types                       = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -106,8 +107,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return attestation.TypeSet{Type}
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/collection.go
+++ b/attestation/collection.go
@@ -42,8 +42,8 @@ func NewCollection(name string, attestors []CompletedAttestor) Collection {
 		Attestations: make([]CollectionAttestation, 0),
 	}
 
-	//move start/stop time to collection
-	//todo: this is a bit of a hack, but it's the easiest way to get the start/stop time
+	// move start/stop time to collection
+	// todo: this is a bit of a hack, but it's the easiest way to get the start/stop time
 
 	for _, completed := range attestors {
 		collection.Attestations = append(collection.Attestations, NewCollectionAttestation(completed))
@@ -54,7 +54,7 @@ func NewCollection(name string, attestors []CompletedAttestor) Collection {
 
 func NewCollectionAttestation(completed CompletedAttestor) CollectionAttestation {
 	return CollectionAttestation{
-		Type:        completed.Attestor.Type(),
+		Type:        completed.Attestor.Type().First(),
 		Attestation: completed.Attestor,
 		StartTime:   completed.StartTime,
 		EndTime:     completed.EndTime,

--- a/attestation/commandrun/commandrun.go
+++ b/attestation/commandrun/commandrun.go
@@ -35,21 +35,22 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor = &CommandRun{}
-	_ CommandRunAttestor   = &CommandRun{}
+	_     attestation.Attestor = &CommandRun{}
+	_     CommandRunAttestor   = &CommandRun{}
+	types                      = attestation.TypeSet{Type}
 )
 
 type CommandRunAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 	Data() *CommandRun
 }
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -152,8 +153,8 @@ func (rc *CommandRun) Name() string {
 	return Name
 }
 
-func (rc *CommandRun) Type() string {
-	return Type
+func (rc *CommandRun) Type() attestation.TypeSet {
+	return types
 }
 
 func (rc *CommandRun) RunType() attestation.RunType {

--- a/attestation/environment/environment.go
+++ b/attestation/environment/environment.go
@@ -33,21 +33,22 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor = &Attestor{}
-	_ EnvironmentAttestor  = &Attestor{}
+	_     attestation.Attestor = &Attestor{}
+	_     EnvironmentAttestor  = &Attestor{}
+	types                      = attestation.TypeSet{Type}
 )
 
 type EnvironmentAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 	Data() *Attestor
 }
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -85,8 +86,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/gcp-iit/gcp-iit.go
+++ b/attestation/gcp-iit/gcp-iit.go
@@ -50,12 +50,13 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Attestor{}
-	_ attestation.Subjecter = &Attestor{}
+	_     attestation.Attestor  = &Attestor{}
+	_     attestation.Subjecter = &Attestor{}
+	types                       = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -91,8 +92,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/git/git.go
+++ b/attestation/git/git.go
@@ -37,16 +37,17 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor   = &Attestor{}
-	_ attestation.Subjecter  = &Attestor{}
-	_ attestation.BackReffer = &Attestor{}
-	_ GitAttestor            = &Attestor{}
+	_     attestation.Attestor   = &Attestor{}
+	_     attestation.Subjecter  = &Attestor{}
+	_     attestation.BackReffer = &Attestor{}
+	_     GitAttestor            = &Attestor{}
+	types                        = attestation.TypeSet{Type}
 )
 
 type GitAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 	Data() *Attestor
@@ -59,7 +60,7 @@ type GitAttestor interface {
 }
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -107,8 +108,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/github/github.go
+++ b/attestation/github/github.go
@@ -46,16 +46,17 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor   = &Attestor{}
-	_ attestation.Subjecter  = &Attestor{}
-	_ attestation.BackReffer = &Attestor{}
-	_ GitHubAttestor         = &Attestor{}
+	_     attestation.Attestor   = &Attestor{}
+	_     attestation.Subjecter  = &Attestor{}
+	_     attestation.BackReffer = &Attestor{}
+	_     GitHubAttestor         = &Attestor{}
+	types                        = attestation.TypeSet{Type}
 )
 
 type GitHubAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 	Data() *Attestor
@@ -69,7 +70,7 @@ type GitHubAttestor interface {
 
 // init registers the github attestor.
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -116,8 +117,8 @@ func (a *Attestor) Name() string {
 }
 
 // Type returns the type of the attestor.
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 // RunType returns the run type of the attestor.

--- a/attestation/gitlab/gitlab.go
+++ b/attestation/gitlab/gitlab.go
@@ -36,16 +36,17 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor   = &Attestor{}
-	_ attestation.Subjecter  = &Attestor{}
-	_ attestation.BackReffer = &Attestor{}
-	_ GitLabAttestor         = &Attestor{}
+	_     attestation.Attestor   = &Attestor{}
+	_     attestation.Subjecter  = &Attestor{}
+	_     attestation.BackReffer = &Attestor{}
+	_     GitLabAttestor         = &Attestor{}
+	types                        = attestation.TypeSet{Type}
 )
 
 type GitLabAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 	Data() *Attestor
@@ -58,7 +59,7 @@ type GitLabAttestor interface {
 }
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -94,8 +95,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/jwt/jwt.go
+++ b/attestation/jwt/jwt.go
@@ -34,11 +34,12 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor = &Attestor{}
+	_     attestation.Attestor = &Attestor{}
+	types                      = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -142,8 +143,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/link/link.go
+++ b/attestation/link/link.go
@@ -42,12 +42,13 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Link{}
-	_ attestation.Subjecter = &Link{}
+	_     attestation.Attestor  = &Link{}
+	_     attestation.Subjecter = &Link{}
+	types                       = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType,
+	attestation.RegisterAttestation(Name, types, RunType,
 		func() attestation.Attestor { return New() },
 		registry.BoolConfigOption(
 			"export",
@@ -87,8 +88,8 @@ func (l *Link) Name() string {
 	return Name
 }
 
-func (l *Link) Type() string {
-	return Type
+func (l *Link) Type() attestation.TypeSet {
+	return types
 }
 
 func (l *Link) RunType() attestation.RunType {

--- a/attestation/material/material.go
+++ b/attestation/material/material.go
@@ -32,15 +32,16 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor   = &Attestor{}
-	_ attestation.Materialer = &Attestor{}
-	_ MaterialAttestor       = &Attestor{}
+	_     attestation.Attestor   = &Attestor{}
+	_     attestation.Materialer = &Attestor{}
+	_     MaterialAttestor       = &Attestor{}
+	types                        = attestation.TypeSet{Type}
 )
 
 type MaterialAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 
@@ -49,7 +50,7 @@ type MaterialAttestor interface {
 }
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -64,8 +65,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return attestation.TypeSet{Type}
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/maven/maven.go
+++ b/attestation/maven/maven.go
@@ -38,12 +38,13 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Attestor{}
-	_ attestation.Subjecter = &Attestor{}
+	_     attestation.Attestor  = &Attestor{}
+	_     attestation.Subjecter = &Attestor{}
+	types                       = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	},
 		registry.StringConfigOption(
@@ -105,8 +106,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -43,15 +43,16 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Attestor{}
-	_ attestation.Subjecter = &Attestor{}
-	_ OCIAttestor           = &Attestor{}
+	_     attestation.Attestor  = &Attestor{}
+	_     attestation.Subjecter = &Attestor{}
+	_     OCIAttestor           = &Attestor{}
+	types                       = attestation.TypeSet{Type}
 )
 
 type OCIAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 
@@ -60,7 +61,7 @@ type OCIAttestor interface {
 }
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -130,8 +131,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/omnitrail/omnitrail.go
+++ b/attestation/omnitrail/omnitrail.go
@@ -28,8 +28,10 @@ const (
 	RunType = attestation.PreMaterialRunType
 )
 
+var types = attestation.TypeSet{Type}
+
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return NewOmnitrailAttestor()
 	})
 }
@@ -69,6 +71,6 @@ func (o *Attestor) Schema() *jsonschema.Schema {
 }
 
 // Type implements attestation.Attestor.
-func (o *Attestor) Type() string {
-	return Type
+func (o *Attestor) Type() attestation.TypeSet {
+	return types
 }

--- a/attestation/policyverify/policyverify.go
+++ b/attestation/policyverify/policyverify.go
@@ -40,12 +40,13 @@ const (
 )
 
 var (
-	_ attestation.Subjecter = &Attestor{}
-	_ attestation.Attestor  = &Attestor{}
+	_     attestation.Subjecter = &Attestor{}
+	_     attestation.Attestor  = &Attestor{}
+	types                       = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -109,8 +110,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/product/product.go
+++ b/attestation/product/product.go
@@ -41,15 +41,16 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Attestor{}
-	_ attestation.Subjecter = &Attestor{}
-	_ attestation.Producer  = &Attestor{}
+	_     attestation.Attestor  = &Attestor{}
+	_     attestation.Subjecter = &Attestor{}
+	_     attestation.Producer  = &Attestor{}
+	types                       = attestation.TypeSet{ProductType}
 )
 
 type ProductAttestor interface {
 	// Attestor
 	Name() string
-	Type() string
+	Type() attestation.TypeSet
 	RunType() attestation.RunType
 	Attest(ctx *attestation.AttestationContext) error
 
@@ -61,7 +62,7 @@ type ProductAttestor interface {
 }
 
 func init() {
-	attestation.RegisterAttestation(ProductName, ProductType, ProductRunType, func() attestation.Attestor { return New() },
+	attestation.RegisterAttestation(ProductName, types, ProductRunType, func() attestation.Attestor { return New() },
 		registry.StringConfigOption(
 			"include-glob",
 			"Pattern to use when recording products. Files that match this pattern will be included as subjects on the attestation.",
@@ -138,8 +139,8 @@ func (a *Attestor) Name() string {
 	return ProductName
 }
 
-func (a *Attestor) Type() string {
-	return ProductType
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {

--- a/attestation/sarif/sarif.go
+++ b/attestation/sarif/sarif.go
@@ -40,10 +40,11 @@ var (
 	_ attestation.Attestor = &Attestor{}
 
 	mimeTypes = []string{"text/plain", "application/json"}
+	types     = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+	attestation.RegisterAttestation(Name, types, RunType, func() attestation.Attestor {
 		return New()
 	})
 }
@@ -62,8 +63,8 @@ func (a *Attestor) Name() string {
 	return Name
 }
 
-func (a *Attestor) Type() string {
-	return Type
+func (a *Attestor) Type() attestation.TypeSet {
+	return types
 }
 
 func (a *Attestor) RunType() attestation.RunType {
@@ -116,7 +117,7 @@ func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 			return fmt.Errorf("error reading file: %s", path)
 		}
 
-		//check to see if we can unmarshal into sarif type
+		// check to see if we can unmarshal into sarif type
 		if err := json.Unmarshal(reportBytes, &a.Report); err != nil {
 			log.Debugf("(attestation/sarif) error unmarshaling report: %w", err)
 			continue

--- a/attestation/slsa/slsa.go
+++ b/attestation/slsa/slsa.go
@@ -53,12 +53,13 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Provenance{}
-	_ attestation.Subjecter = &Provenance{}
+	_     attestation.Attestor  = &Provenance{}
+	_     attestation.Subjecter = &Provenance{}
+	types                       = attestation.TypeSet{Type}
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType,
+	attestation.RegisterAttestation(Name, types, RunType,
 		func() attestation.Attestor { return New() },
 		registry.BoolConfigOption(
 			"export",
@@ -99,8 +100,8 @@ func (p *Provenance) Name() string {
 	return Name
 }
 
-func (p *Provenance) Type() string {
-	return Type
+func (p *Provenance) Type() attestation.TypeSet {
+	return types
 }
 
 func (p *Provenance) RunType() attestation.RunType {

--- a/internal/attestors/commandrun.go
+++ b/internal/attestors/commandrun.go
@@ -36,7 +36,7 @@ func (t *TestCommandRunAttestor) Name() string {
 	return t.comAtt.Name()
 }
 
-func (t *TestCommandRunAttestor) Type() string {
+func (t *TestCommandRunAttestor) Type() attestation.TypeSet {
 	return t.comAtt.Type()
 }
 

--- a/internal/attestors/environment.go
+++ b/internal/attestors/environment.go
@@ -35,7 +35,7 @@ func (t *TestEnvironmentAttestor) Name() string {
 	return t.environmentAtt.Name()
 }
 
-func (t *TestEnvironmentAttestor) Type() string {
+func (t *TestEnvironmentAttestor) Type() attestation.TypeSet {
 	return t.environmentAtt.Type()
 }
 

--- a/internal/attestors/git.go
+++ b/internal/attestors/git.go
@@ -36,7 +36,7 @@ func (t *TestGitAttestor) Name() string {
 	return t.gitAtt.Name()
 }
 
-func (t *TestGitAttestor) Type() string {
+func (t *TestGitAttestor) Type() attestation.TypeSet {
 	return t.gitAtt.Type()
 }
 

--- a/internal/attestors/github.go
+++ b/internal/attestors/github.go
@@ -38,7 +38,7 @@ func (t *TestGitHubAttestor) Name() string {
 	return t.githubAtt.Name()
 }
 
-func (t *TestGitHubAttestor) Type() string {
+func (t *TestGitHubAttestor) Type() attestation.TypeSet {
 	return t.githubAtt.Type()
 }
 

--- a/internal/attestors/gitlab.go
+++ b/internal/attestors/gitlab.go
@@ -38,7 +38,7 @@ func (t *TestGitLabAttestor) Name() string {
 	return t.gitlabAtt.Name()
 }
 
-func (t *TestGitLabAttestor) Type() string {
+func (t *TestGitLabAttestor) Type() attestation.TypeSet {
 	return t.gitlabAtt.Type()
 }
 

--- a/internal/attestors/material.go
+++ b/internal/attestors/material.go
@@ -38,7 +38,7 @@ func (t *TestMaterialAttestor) Name() string {
 	return t.matAtt.Name()
 }
 
-func (t *TestMaterialAttestor) Type() string {
+func (t *TestMaterialAttestor) Type() attestation.TypeSet {
 	return t.matAtt.Type()
 }
 

--- a/internal/attestors/oci.go
+++ b/internal/attestors/oci.go
@@ -36,7 +36,7 @@ func (t *TestOCIAttestor) Name() string {
 	return t.ociAtt.Name()
 }
 
-func (t *TestOCIAttestor) Type() string {
+func (t *TestOCIAttestor) Type() attestation.TypeSet {
 	return t.ociAtt.Type()
 }
 

--- a/internal/attestors/product.go
+++ b/internal/attestors/product.go
@@ -36,7 +36,7 @@ func (t *TestProductAttestor) Name() string {
 	return t.prodAtt.Name()
 }
 
-func (t *TestProductAttestor) Type() string {
+func (t *TestProductAttestor) Type() attestation.TypeSet {
 	return t.prodAtt.Type()
 }
 

--- a/run.go
+++ b/run.go
@@ -137,7 +137,7 @@ func run(stepName string, opts []RunOption) ([]RunResult, error) {
 					continue
 				}
 				if subjecter, ok := r.Attestor.(attestation.Subjecter); ok {
-					envelope, err := createAndSignEnvelope(r.Attestor, r.Attestor.Type(), subjecter.Subjects(), dsse.SignWithSigners(ro.signers...), dsse.SignWithTimestampers(ro.timestampers...))
+					envelope, err := createAndSignEnvelope(r.Attestor, r.Attestor.Type().First(), subjecter.Subjects(), dsse.SignWithSigners(ro.signers...), dsse.SignWithTimestampers(ro.timestampers...))
 					if err != nil {
 						return result, fmt.Errorf("failed to sign envelope: %w", err)
 					}

--- a/source/memory.go
+++ b/source/memory.go
@@ -96,7 +96,7 @@ func (s *MemorySource) LoadEnvelope(reference string, env dsse.Envelope) error {
 	s.subjectDigestsByReference[reference] = subDigestIndex
 	attestationIndex := make(map[string]struct{})
 	for _, att := range collEnv.Collection.Attestations {
-		attestationIndex[att.Attestation.Type()] = struct{}{}
+		attestationIndex[att.Attestation.Type().First()] = struct{}{}
 	}
 
 	s.attestationsByReference[reference] = attestationIndex


### PR DESCRIPTION
## What this PR does / why we need it

This PR introduces the ability to define more than one Predicate Type through the `Type` method in the `Attestor` interface. The first string in the `TypeSet` is treated as the "primary" type (e.g., `https://witness.dev/attestations/sbom/v0.1`) and can be returned with the `First()` function.

When initializing the `attestationsByType` map, each type in the `TypeSet` for a given attestor is added as a key with the attestor as its value.