### PR TITLE
fix: Passing kms provider options down to initialisation of functionaries

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,4 +43,4 @@ jobs:
         with:
           version: latest
           args: --timeout=3m
-          skip-pkg-cache: true
+          skip-cache: true

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -76,18 +76,17 @@ func (p Policy) PublicKeyVerifiers(ko map[string][]func(signer.SignerProvider) (
 					}
 				}
 
-				kspv, ok := vp.(*kms.KMSSignerProvider)
-				if !ok {
-					return nil, fmt.Errorf("provided verifier provider is not a KMS verifier provider")
+				if vp != nil {
+					var ok bool
+					ksp, ok = vp.(*kms.KMSSignerProvider)
+					if !ok {
+						return nil, fmt.Errorf("provided verifier provider is not a KMS verifier provider")
+					}
 				}
 
-				verifier, err = kspv.Verifier(context.TODO())
+				verifier, err = ksp.Verifier(context.TODO())
 				if err != nil {
 					return nil, fmt.Errorf("failed to create kms verifier: %w", err)
-				}
-
-				if err != nil {
-					return nil, fmt.Errorf("KMS Key ID recognized but not valid: %w", err)
 				}
 
 			}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/in-toto/go-witness/attestation/commandrun"
 	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/in-toto/go-witness/intoto"
+	"github.com/in-toto/go-witness/signer"
 	"github.com/in-toto/go-witness/source"
 	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
@@ -483,7 +484,7 @@ func TestPubKeyVerifiers(t *testing.T) {
 				}
 			}
 
-			verifiers, err := p.PublicKeyVerifiers()
+			verifiers, err := p.PublicKeyVerifiers(map[string][]func(signer.SignerProvider) (signer.SignerProvider, error){})
 			if testCase.expectedErr == nil {
 				assert.NoError(t, err)
 				assert.Len(t, verifiers, testCase.expectedLen)

--- a/signer/kms/aws/client.go
+++ b/signer/kms/aws/client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -303,7 +304,6 @@ func (a *awsClient) setupClient(ctx context.Context, ksp *kms.KMSSignerProvider)
 	}
 
 	opts := []func(*config.LoadOptions) error{}
-
 	if a.options.insecureSkipVerify {
 		log.Warn("InsecureSkipVerify is enabled for AWS KMS attestor")
 		opts = append(opts, config.WithHTTPClient(&http.Client{
@@ -320,6 +320,9 @@ func (a *awsClient) setupClient(ctx context.Context, ksp *kms.KMSSignerProvider)
 		}
 
 		log.Debug("Using file ", f, " as credentials file for AWS KMS provider")
+		if _, err := os.ReadFile(f); err != nil {
+			return fmt.Errorf("error reading credentials file: %w", err)
+		}
 		opts = append(opts, config.WithSharedCredentialsFiles([]string{f}))
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it

this closes https://github.com/in-toto/witness/issues/427