### PR TITLE
better concurrency support on Linux

### DIFF
--- a/attestation/commandrun/commandrun.go
+++ b/attestation/commandrun/commandrun.go
@@ -70,7 +70,7 @@ func WithMaterials(materials map[string]cryptoutil.DigestSet) Option {
 
 func WithTracing(enabled bool) Option {
 	return func(cr *CommandRun) {
-		cr.enableTracing = enabled
+		cr.EnableTracing = enabled
 	}
 }
 
@@ -117,10 +117,10 @@ type CommandRun struct {
 	Stderr    string        `json:"stderr,omitempty"`
 	ExitCode  int           `json:"exitcode"`
 	Processes []ProcessInfo `json:"processes,omitempty"`
+	EnableTracing        bool
 
 	silent               bool
 	materials            map[string]cryptoutil.DigestSet
-	enableTracing        bool
 	environmentBlockList map[string]struct{}
 }
 
@@ -176,7 +176,7 @@ func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	stderrWriter := io.MultiWriter(stderrWriters...)
 	c.Stdout = stdoutWriter
 	c.Stderr = stderrWriter
-	if r.enableTracing {
+	if r.EnableTracing {
 		enableTracing(c)
 	}
 
@@ -185,7 +185,7 @@ func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	}
 
 	var err error
-	if r.enableTracing {
+	if r.EnableTracing {
 		r.Processes, err = r.trace(c, ctx)
 	} else {
 		err = c.Wait()

--- a/attestation/commandrun/commandrun.go
+++ b/attestation/commandrun/commandrun.go
@@ -70,7 +70,7 @@ func WithMaterials(materials map[string]cryptoutil.DigestSet) Option {
 
 func WithTracing(enabled bool) Option {
 	return func(cr *CommandRun) {
-		cr.EnableTracing = enabled
+		cr.enableTracing = enabled
 	}
 }
 
@@ -117,10 +117,10 @@ type CommandRun struct {
 	Stderr    string        `json:"stderr,omitempty"`
 	ExitCode  int           `json:"exitcode"`
 	Processes []ProcessInfo `json:"processes,omitempty"`
-	EnableTracing        bool
 
 	silent               bool
 	materials            map[string]cryptoutil.DigestSet
+	enableTracing        bool
 	environmentBlockList map[string]struct{}
 }
 
@@ -160,6 +160,10 @@ func (rc *CommandRun) RunType() attestation.RunType {
 	return RunType
 }
 
+func (rc *CommandRun) EnableTracing() bool {
+	return rc.enableTracing
+}
+
 func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	c := exec.Command(r.Cmd[0], r.Cmd[1:]...)
 	c.Dir = ctx.WorkingDir()
@@ -176,7 +180,7 @@ func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	stderrWriter := io.MultiWriter(stderrWriters...)
 	c.Stdout = stdoutWriter
 	c.Stderr = stderrWriter
-	if r.EnableTracing {
+	if r.enableTracing {
 		enableTracing(c)
 	}
 
@@ -185,7 +189,7 @@ func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	}
 
 	var err error
-	if r.EnableTracing {
+	if r.enableTracing {
 		r.Processes, err = r.trace(c, ctx)
 	} else {
 		err = c.Wait()

--- a/attestation/commandrun/commandrun.go
+++ b/attestation/commandrun/commandrun.go
@@ -160,7 +160,7 @@ func (rc *CommandRun) RunType() attestation.RunType {
 	return RunType
 }
 
-func (rc *CommandRun) EnableTracing() bool {
+func (rc *CommandRun) TracingEnabled() bool {
 	return rc.enableTracing
 }
 

--- a/attestation/commandrun/tracing_linux.go
+++ b/attestation/commandrun/tracing_linux.go
@@ -75,7 +75,7 @@ func (r *CommandRun) trace(c *exec.Cmd, actx *attestation.AttestationContext) ([
 
 func (p *ptraceContext) runTrace() error {
 	defer p.retryOpenedFiles()
-	
+
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	status := unix.WaitStatus(0)

--- a/attestation/commandrun/tracing_linux.go
+++ b/attestation/commandrun/tracing_linux.go
@@ -74,6 +74,8 @@ func (r *CommandRun) trace(c *exec.Cmd, actx *attestation.AttestationContext) ([
 }
 
 func (p *ptraceContext) runTrace() error {
+	defer p.retryOpenedFiles()
+	
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	status := unix.WaitStatus(0)
@@ -118,6 +120,26 @@ func (p *ptraceContext) runTrace() error {
 		if err := unix.PtraceSyscall(pid, injectedSig); err != nil {
 			log.Debugf("(tracing) got error from ptrace syscall: %w", err)
 		}
+	}
+}
+
+func (p *ptraceContext) retryOpenedFiles() {
+	// after tracing, look through opened files to try to resolve any newly created files
+	procInfo := p.getProcInfo(p.parentPid)
+
+	for file, digestSet := range procInfo.OpenedFiles {
+		if digestSet != nil {
+			continue
+		}
+
+		newDigest, err := cryptoutil.CalculateDigestSetFromFile(file, p.hash)
+
+		if err != nil {
+			delete(procInfo.OpenedFiles, file)
+			continue
+		}
+
+		procInfo.OpenedFiles[file] = newDigest
 	}
 }
 
@@ -213,6 +235,10 @@ func (p *ptraceContext) handleSyscall(pid int, regs unix.PtraceRegs) error {
 		procInfo := p.getProcInfo(pid)
 		digestSet, err := cryptoutil.CalculateDigestSetFromFile(file, p.hash)
 		if err != nil {
+			if _, isPathErr := err.(*os.PathError); isPathErr {
+				procInfo.OpenedFiles[file] = nil
+			}
+
 			return err
 		}
 

--- a/attestation/file/file.go
+++ b/attestation/file/file.go
@@ -26,7 +26,7 @@ import (
 // recordArtifacts will walk basePath and record the digests of each file with each of the functions in hashes.
 // If file already exists in baseArtifacts and the two artifacts are equal the artifact will not be in the
 // returned map of artifacts.
-func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}) (map[string]cryptoutil.DigestSet, error) {
+func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}, processWasTraced bool, openedFiles map[string]bool) (map[string]cryptoutil.DigestSet, error) {
 	artifacts := make(map[string]cryptoutil.DigestSet)
 	err := filepath.Walk(basePath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -57,7 +57,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			}
 
 			visitedSymlinks[linkedPath] = struct{}{}
-			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks)
+			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles)
 			if err != nil {
 				return err
 			}
@@ -65,7 +65,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			for artifactPath, artifact := range symlinkedArtifacts {
 				// all artifacts in the symlink should be recorded relative to our basepath
 				joinedPath := filepath.Join(relPath, artifactPath)
-				if shouldRecord(joinedPath, artifact, baseArtifacts) {
+				if shouldRecord(joinedPath, artifact, baseArtifacts, processWasTraced, openedFiles) {
 					artifacts[filepath.Join(relPath, artifactPath)] = artifact
 				}
 			}
@@ -78,7 +78,7 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			return err
 		}
 
-		if shouldRecord(relPath, artifact, baseArtifacts) {
+		if shouldRecord(relPath, artifact, baseArtifacts, processWasTraced, openedFiles) {
 			artifacts[relPath] = artifact
 		}
 
@@ -89,9 +89,13 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 }
 
 // shouldRecord determines whether artifact should be recorded.
+// if the process was traced and the artifact was not one of the opened files, return false
 // if the artifact is already in baseArtifacts, check if it's changed
 // if it is not equal to the existing artifact, return true, otherwise return false
-func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet) bool {
+func shouldRecord(path string, artifact cryptoutil.DigestSet, baseArtifacts map[string]cryptoutil.DigestSet, processWasTraced bool, openedFiles map[string]bool) bool {
+	if _, ok := openedFiles[path]; !ok && processWasTraced {
+		return false
+	}
 	if previous, ok := baseArtifacts[path]; ok && artifact.Equal(previous) {
 		return false
 	}

--- a/attestation/file/file_test.go
+++ b/attestation/file/file_test.go
@@ -38,13 +38,13 @@ func TestBrokenSymlink(t *testing.T) {
 	symTestDir := filepath.Join(dir, "symTestDir")
 	require.NoError(t, os.Symlink(testDir, symTestDir))
 
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{})
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool)
 	require.NoError(t, err)
 
 	// remove the symlinks and make sure we don't get an error back
 	require.NoError(t, os.RemoveAll(testDir))
 	require.NoError(t, os.RemoveAll(testFile))
-	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{})
+	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool)
 	require.NoError(t, err)
 }
 
@@ -58,6 +58,6 @@ func TestSymlinkCycle(t *testing.T) {
 	require.NoError(t, os.Symlink(dir, symTestDir))
 
 	// if a symlink cycle weren't properly handled this would be an infinite loop
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{})
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool)
 	require.NoError(t, err)
 }

--- a/attestation/file/file_test.go
+++ b/attestation/file/file_test.go
@@ -38,13 +38,13 @@ func TestBrokenSymlink(t *testing.T) {
 	symTestDir := filepath.Join(dir, "symTestDir")
 	require.NoError(t, os.Symlink(testDir, symTestDir))
 
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool)
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{})
 	require.NoError(t, err)
 
 	// remove the symlinks and make sure we don't get an error back
 	require.NoError(t, os.RemoveAll(testDir))
 	require.NoError(t, os.RemoveAll(testFile))
-	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool)
+	_, err = RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{})
 	require.NoError(t, err)
 }
 
@@ -58,6 +58,6 @@ func TestSymlinkCycle(t *testing.T) {
 	require.NoError(t, os.Symlink(dir, symTestDir))
 
 	// if a symlink cycle weren't properly handled this would be an infinite loop
-	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool)
+	_, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{})
 	require.NoError(t, err)
 }

--- a/attestation/material/material.go
+++ b/attestation/material/material.go
@@ -90,7 +90,7 @@ func (a *Attestor) Schema() *jsonschema.Schema {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{})
+	materials, err := file.RecordArtifacts(ctx.WorkingDir(), nil, ctx.Hashes(), map[string]struct{}{}, false, map[string]bool{})
 	if err != nil {
 		return err
 	}

--- a/attestation/product/product.go
+++ b/attestation/product/product.go
@@ -188,12 +188,12 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	for _, completedAttestor := range ctx.CompletedAttestors() {
 		attestor := completedAttestor.Attestor
-		if commandRunAttestor, ok := attestor.(*commandrun.CommandRun); ok && commandRunAttestor.EnableTracing {
+		if commandRunAttestor, ok := attestor.(*commandrun.CommandRun); ok && commandRunAttestor.EnableTracing() {
 			processWasTraced = true
 
 			for _, process := range commandRunAttestor.Processes {
-				for file := range process.OpenedFiles {
-					openedFileSet[file] = true;
+				for fname := range process.OpenedFiles {
+					openedFileSet[fname] = true
 				}
 			}
 		}

--- a/attestation/product/product.go
+++ b/attestation/product/product.go
@@ -188,7 +188,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	for _, completedAttestor := range ctx.CompletedAttestors() {
 		attestor := completedAttestor.Attestor
-		if commandRunAttestor, ok := attestor.(*commandrun.CommandRun); ok && commandRunAttestor.EnableTracing() {
+		if commandRunAttestor, ok := attestor.(*commandrun.CommandRun); ok && commandRunAttestor.TracingEnabled() {
 			processWasTraced = true
 
 			for _, process := range commandRunAttestor.Processes {


### PR DESCRIPTION
## What this PR does / why we need it
- When ptracing programs, restrict the product attestor to only attest for files recorded as "opened" by the commandrun attestor. Then, files created by a separate process running concurrently will not be mistakenly included in the attestation products (this happens currently).
- Keep track of newly created files when tracing with ptrace. Previously, they would not be added to the `OpenedFiles` list because the file would not exist when attempting to calculate its digest.

## Which issue(s) this PR fixes (optional)

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
