### PR TITLE
fix: repetitive and incorrect log lines on `witness verify`

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -217,30 +217,30 @@ func (p Policy) Verify(ctx context.Context, opts ...VerifyOption) (bool, map[str
 	resultsByStep := make(map[string]StepResult)
 	for depth := 0; depth < vo.searchDepth; depth++ {
 		for stepName, step := range p.Steps {
-			// Use search to get all the attestations that match the supplied step name and subjects
+			// initialize the result for this step if it hasn't been already
+			if _, ok := resultsByStep[stepName]; !ok {
+				resultsByStep[stepName] = StepResult{Step: stepName}
+			}
+
 			collections, err := vo.verifiedSource.Search(ctx, stepName, vo.subjectDigests, attestationsByStep[stepName])
 			if err != nil {
 				return false, nil, err
 			}
 
 			if len(collections) == 0 {
-				collections = append(collections, source.CollectionVerificationResult{Errors: []error{ErrNoCollections{Step: stepName}}})
+				continue
 			}
 
-			// Verify the functionaries
+			// Verify the functionaries and validate attestations
 			collections = step.checkFunctionaries(collections, trustBundles)
-
 			stepResult := step.validateAttestations(collections)
 
-			// We perform many searches against the same step, so we need to merge the relevant fields
-			if resultsByStep[stepName].Step == "" {
-				resultsByStep[stepName] = stepResult
-			} else {
-				if result, ok := resultsByStep[stepName]; ok {
-					result.Passed = append(result.Passed, stepResult.Passed...)
-					result.Rejected = append(result.Rejected, stepResult.Rejected...)
-					resultsByStep[stepName] = result
-				}
+			// Merge the results
+			if result, ok := resultsByStep[stepName]; ok {
+				result.Passed = append(result.Passed, stepResult.Passed...)
+				result.Rejected = append(result.Rejected, stepResult.Rejected...)
+
+				resultsByStep[stepName] = result
 			}
 
 			for _, coll := range stepResult.Passed {
@@ -303,13 +303,6 @@ func (p Policy) verifyArtifacts(resultsByStep map[string]StepResult) (map[string
 	for _, step := range p.Steps {
 		accepted := false
 		if len(resultsByStep[step.Name].Passed) == 0 {
-			if result, ok := resultsByStep[step.Name]; ok {
-				result.Rejected = append(result.Rejected, RejectedCollection{Reason: fmt.Errorf("failed to verify artifacts for step %s: no passed collections present", step.Name)})
-				resultsByStep[step.Name] = result
-			} else {
-				return nil, fmt.Errorf("failed to find step %s in step results map", step.Name)
-			}
-
 			continue
 		}
 

--- a/policy/step.go
+++ b/policy/step.go
@@ -184,7 +184,7 @@ func (s Step) validateAttestations(collectionResults []source.CollectionVerifica
 		if passed {
 			result.Passed = append(result.Passed, collection)
 		} else {
-			r := strings.Join(reasons, ",\n - ")
+			r := strings.Join(reasons, "\n - ")
 			reason := fmt.Sprintf("collection validation failed:\n - %s", r)
 			result.Rejected = append(result.Rejected, RejectedCollection{
 				Collection: collection,


### PR DESCRIPTION
## What this PR does / why we need it

This PR closes #316 where repeated verification lines existed that looked repeated. It also fixes log lines incorrectly reporting that certain attestations weren't seen. It does so by:
- removing some unnecessary functionality that was duplicating the job of checking for the presence of certain attestations in the collection
- not continuing through the verification flow if no collection was found from a search
- preventing the memory source repeating the search process more than once. memory (attestation files) is a flat data structure so there is only a need to search once.

## Which issue(s) this PR fixes (optional)
#316

## Other Notes
This PR will be supplemented by a small PR (update: https://github.com/in-toto/witness/pull/485) in https://github.com/in-toto/witness. While it is possible to test this without that branch, some of the reported log lines will still seem slightly misleading / confusing.
