### PR TITLE
improve SPDX and CycloneDX JSON SBOM format detection

### DIFF
--- a/attestation/product/product.go
+++ b/attestation/product/product.go
@@ -243,15 +243,25 @@ func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 	return subjects
 }
 
+func IsSPDXJson(buf []byte) bool {
+	header := buf[:500]
+	return bytes.Contains(header, []byte(`"spdxVersion":"SPDX-`)) || bytes.Contains(header, []byte(`"spdxVersion": "SPDX-`))
+}
+
+func IsCycloneDXJson(buf []byte) bool {
+	header := buf[:500]
+	return bytes.Contains(header, []byte(`"bomFormat":"CycloneDX"`)) || bytes.Contains(header, []byte(`"bomFormat": "CycloneDX"`))
+}
+
 func getFileContentType(fileName string) (string, error) {
 	// Add SPDX JSON detector
 	mimetype.Lookup("application/json").Extend(func(buf []byte, limit uint32) bool {
-		return bytes.HasPrefix(buf, []byte(`{"spdxVersion":"SPDX-`))
+		return IsSPDXJson(buf)
 	}, "application/spdx+json", ".spdx.json")
 
 	// Add CycloneDx JSON detector
 	mimetype.Lookup("application/json").Extend(func(buf []byte, limit uint32) bool {
-		return bytes.HasPrefix(buf, []byte(`{"$schema":"http://cyclonedx.org/schema/bom-`))
+		return IsCycloneDXJson(buf)
 	}, "application/vnd.cyclonedx+json", ".cdx.json")
 
 	// Add CycloneDx XML detector

--- a/attestation/sbom/sbom.go
+++ b/attestation/sbom/sbom.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/attestation/product"
 	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/in-toto/go-witness/log"
 	"github.com/in-toto/go-witness/registry"
@@ -129,9 +130,9 @@ func (a *SBOMAttestor) MarshalJSON() ([]byte, error) {
 }
 
 func (a *SBOMAttestor) UnmarshalJSON(data []byte) error {
-	if bytes.HasPrefix(data, []byte(`{"spdxVersion":"SPDX-`)) {
+	if product.IsSPDXJson(data) {
 		a.predicateType = SPDXPredicateType
-	} else if bytes.HasPrefix(data, []byte(`{"$schema":"http://cyclonedx.org/schema/bom-`)) {
+	} else if product.IsCycloneDXJson(data) {
 		a.predicateType = CycloneDxPredicateType
 	} else {
 		log.Warn("Unknown sbom predicate type")


### PR DESCRIPTION
## What this PR does / why we need it
The current CycloneDX and SPDX checks are too naive, meaning some generated SBOMs will not be correctly detected as SBOMs. This will introduce a more lenient check for identifying information which indicates the format of the SBOM without overly sacrificing performance.

The check will see if a file's first 500 characters contains identifying information related to the type of SBOM the file might be, rather than the naive HasPrefix check.

## Which issue(s) this PR fixes (optional)

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
