### PR TITLE
fix: golangci-lint failing due nil check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,8 @@ schema: ## Generate the attestor schema json files
 
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+lint: ## Run the linter
+	@golangci-lint run
+	@go fmt ./...
+	@go vet ./...

--- a/dsse/verify.go
+++ b/dsse/verify.go
@@ -95,7 +95,7 @@ func (e Envelope) Verify(opts ...VerificationOption) ([]CheckedVerifier, error) 
 	checkedVerifiers := make([]CheckedVerifier, 0)
 	verified := 0
 	for _, sig := range e.Signatures {
-		if sig.Certificate != nil && len(sig.Certificate) > 0 {
+		if len(sig.Certificate) > 0 {
 			cert, err := cryptoutil.TryParseCertificate(sig.Certificate)
 			if err != nil {
 				continue


### PR DESCRIPTION
## What this PR does / why we need it

Added the fix and introduced `make lint` for local tests.

```
dsse/verify.go:98:6: S1009: should omit nil check; len() for []byte is defined as zero (gosimple)
                if sig.Certificate != nil && len(sig.Certificate) > 0 {
                   ^
```


## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
