### PR TITLE
revert: fix: repetitive and incorrect log lines on `witness verify` (…

### DIFF
--- a/policy/step.go
+++ b/policy/step.go
@@ -184,7 +184,7 @@ func (s Step) validateAttestations(collectionResults []source.CollectionVerifica
 		if passed {
 			result.Passed = append(result.Passed, collection)
 		} else {
-			r := strings.Join(reasons, "\n - ")
+			r := strings.Join(reasons, ",\n - ")
 			reason := fmt.Sprintf("collection validation failed:\n - %s", r)
 			result.Rejected = append(result.Rejected, RejectedCollection{
 				Collection: collection,

--- a/source/memory.go
+++ b/source/memory.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/in-toto/go-witness/dsse"
-	"github.com/in-toto/go-witness/log"
 )
 
 type ErrDuplicateReference string
@@ -32,7 +31,6 @@ func (e ErrDuplicateReference) Error() string {
 }
 
 type MemorySource struct {
-	searched                   bool
 	envelopesByReference       map[string]CollectionEnvelope
 	referencesByCollectionName map[string][]string
 	subjectDigestsByReference  map[string]map[string]struct{}
@@ -41,7 +39,6 @@ type MemorySource struct {
 
 func NewMemorySource() *MemorySource {
 	return &MemorySource{
-		searched:                   false,
 		envelopesByReference:       make(map[string]CollectionEnvelope),
 		referencesByCollectionName: make(map[string][]string),
 		subjectDigestsByReference:  make(map[string]map[string]struct{}),
@@ -107,13 +104,6 @@ func (s *MemorySource) LoadEnvelope(reference string, env dsse.Envelope) error {
 }
 
 func (s *MemorySource) Search(ctx context.Context, collectionName string, subjectDigests, attestations []string) ([]CollectionEnvelope, error) {
-	if s.searched {
-		log.Debug("skipping memory source search: already performed")
-		return []CollectionEnvelope{}, nil
-	} else {
-		s.searched = true
-	}
-
 	matches := make([]CollectionEnvelope, 0)
 	for _, potentialMatchReference := range s.referencesByCollectionName[collectionName] {
 		env, ok := s.envelopesByReference[potentialMatchReference]
@@ -132,6 +122,20 @@ func (s *MemorySource) Search(ctx context.Context, collectionName string, subjec
 		}
 
 		if !subjectMatchFound {
+			continue
+		}
+
+		// make sure all the expected attestations appear in the collection
+		attestationsMatched := true
+		indexAttestations := s.attestationsByReference[potentialMatchReference]
+		for _, checkAttestation := range attestations {
+			if _, ok := indexAttestations[checkAttestation]; !ok {
+				attestationsMatched = false
+				break
+			}
+		}
+
+		if !attestationsMatched {
 			continue
 		}
 

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,218 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package witness
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/attestation/commandrun"
+	"github.com/in-toto/go-witness/attestation/material"
+	"github.com/in-toto/go-witness/attestation/product"
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/dsse"
+	"github.com/in-toto/go-witness/policy"
+	"github.com/in-toto/go-witness/source"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVerify(t *testing.T) {
+	policy, functionarySigner := makepolicyRSA(t)
+	policyEnvelope, policySigner := signPolicyRSA(t, policy)
+	policyVerifier, err := policySigner.Verifier()
+	require.NoError(t, err)
+	workingDir := t.TempDir()
+
+	step1Result, err := Run(
+		"step01",
+		RunWithSigners(functionarySigner),
+		RunWithAttestors([]attestation.Attestor{
+			material.New(),
+			commandrun.New(
+				commandrun.WithCommand([]string{"bash", "-c", "echo 'test01' > test.txt"}),
+			),
+			product.New(),
+		}),
+		RunWithAttestationOpts(
+			attestation.WithWorkingDir(workingDir),
+		),
+	)
+	require.NoError(t, err)
+
+	subjects := []cryptoutil.DigestSet{}
+	artifactSubject, err := cryptoutil.CalculateDigestSetFromFile(
+		filepath.Join(workingDir, "test.txt"),
+		[]cryptoutil.DigestValue{
+			{
+				GitOID: false,
+				Hash:   crypto.SHA256,
+			},
+		},
+	)
+	require.NoError(t, err)
+	subjects = append(subjects, artifactSubject)
+
+	step2Result, err := Run(
+		"step02",
+		RunWithSigners(functionarySigner),
+		RunWithAttestors([]attestation.Attestor{
+			material.New(),
+			commandrun.New(
+				commandrun.WithCommand([]string{"bash", "-c", "echo 'test02' >> test.txt"}),
+			),
+			product.New(),
+		}),
+		RunWithAttestationOpts(
+			attestation.WithWorkingDir(workingDir),
+		),
+	)
+	require.NoError(t, err)
+
+	artifactSubject, err = cryptoutil.CalculateDigestSetFromFile(
+		filepath.Join(workingDir, "test.txt"),
+		[]cryptoutil.DigestValue{
+			{
+				GitOID: false,
+				Hash:   crypto.SHA256,
+			},
+		},
+	)
+	require.NoError(t, err)
+	subjects = append(subjects, artifactSubject)
+
+	t.Run("Pass", func(t *testing.T) {
+		memorySource := source.NewMemorySource()
+		require.NoError(t, memorySource.LoadEnvelope("step01", step1Result.SignedEnvelope))
+		require.NoError(t, memorySource.LoadEnvelope("step02", step2Result.SignedEnvelope))
+
+		results, err := Verify(
+			context.Background(),
+			policyEnvelope,
+			[]cryptoutil.Verifier{policyVerifier},
+			VerifyWithCollectionSource(memorySource),
+			VerifyWithSubjectDigests(subjects),
+		)
+
+		require.NoError(t, err, fmt.Sprintf("failed with results: %+v", results))
+	})
+
+	t.Run("Fail with missing collection", func(t *testing.T) {
+		memorySource := source.NewMemorySource()
+		require.NoError(t, memorySource.LoadEnvelope("step01", step1Result.SignedEnvelope))
+
+		results, err := Verify(
+			context.Background(),
+			policyEnvelope,
+			[]cryptoutil.Verifier{policyVerifier},
+			VerifyWithCollectionSource(memorySource),
+			VerifyWithSubjectDigests(subjects),
+		)
+
+		require.Error(t, err, fmt.Sprintf("passed with results: %+v", results))
+	})
+}
+
+func makepolicy(functionary policy.Functionary, publicKey policy.PublicKey, roots map[string]policy.Root) policy.Policy {
+	step01 := policy.Step{
+		Name:          "step01",
+		Functionaries: []policy.Functionary{functionary},
+		Attestations:  []policy.Attestation{{Type: commandrun.Type}},
+	}
+
+	step02 := policy.Step{
+		Name:          "step02",
+		Functionaries: []policy.Functionary{functionary},
+		Attestations:  []policy.Attestation{{Type: commandrun.Type}},
+		ArtifactsFrom: []string{"step01"},
+	}
+
+	p := policy.Policy{
+		Expires:    metav1.Time{Time: time.Now().Add(1 * time.Hour)},
+		PublicKeys: map[string]policy.PublicKey{},
+		Steps:      map[string]policy.Step{},
+	}
+
+	if functionary.CertConstraint.Roots != nil {
+		p.Roots = roots
+	}
+
+	p.Steps = make(map[string]policy.Step)
+	p.Steps[step01.Name] = step01
+	p.Steps[step02.Name] = step02
+
+	if publicKey.KeyID != "" {
+		p.PublicKeys[publicKey.KeyID] = publicKey
+	}
+
+	return p
+}
+
+func makepolicyRSA(t *testing.T) (policy.Policy, cryptoutil.Signer) {
+	signer, err := createTestRSAKey()
+	require.NoError(t, err)
+	verifier, err := signer.Verifier()
+	require.NoError(t, err)
+	keyID, err := verifier.KeyID()
+	require.NoError(t, err)
+	functionary := policy.Functionary{
+		Type:        "PublicKey",
+		PublicKeyID: keyID,
+	}
+
+	pub, err := verifier.Bytes()
+	require.NoError(t, err)
+
+	pk := policy.PublicKey{
+		KeyID: keyID,
+		Key:   pub,
+	}
+
+	p := makepolicy(functionary, pk, nil)
+	return p, signer
+}
+
+func signPolicyRSA(t *testing.T, p policy.Policy) (dsse.Envelope, cryptoutil.Signer) {
+	signer, err := createTestRSAKey()
+	require.NoError(t, err)
+	pBytes, err := json.Marshal(p)
+	require.NoError(t, err)
+	reader := bytes.NewReader(pBytes)
+	outBytes := []byte{}
+	writer := bytes.NewBuffer(outBytes)
+	require.NoError(t, Sign(reader, policy.PolicyPredicate, writer, dsse.SignWithSigners(signer)))
+	env := dsse.Envelope{}
+	require.NoError(t, json.Unmarshal(writer.Bytes(), &env))
+	return env, signer
+}
+
+func createTestRSAKey() (cryptoutil.Signer, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		return nil, err
+	}
+
+	signer := cryptoutil.NewRSASigner(privKey, crypto.SHA256)
+	return signer, nil
+}


### PR DESCRIPTION
…#317)"

This reverts commit 26ee2dc6de37ccad233695aeb38ab18fb8108013.

This commit breaks policy evaluations, causing good policies to fail.

Also added is a test to catch these types of errors in the future. This is just a base case test; we will need to expand our testing around policy verification to ensure this is more resilient to breakages.

## What this PR does / why we need it

Description

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
