### PR TITLE
chore: Improve the git status speed.

### DIFF
--- a/attestation/git/git.go
+++ b/attestation/git/git.go
@@ -79,6 +79,9 @@ type Tag struct {
 }
 
 type Attestor struct {
+	GitTool        string               `json:"gittool"`
+	GitBinPath     string               `json:"gitbinpath,omitempty"`
+	GitBinHash     string               `json:"gitbinhash,omitempty"`
 	CommitHash     string               `json:"commithash"`
 	Author         string               `json:"author"`
 	AuthorEmail    string               `json:"authoremail"`
@@ -222,11 +225,25 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	a.TreeHash = commit.TreeHash.String()
 
 	if GitExists() {
+		a.GitTool = "go-git+git-bin"
+
+		a.GitBinPath, err = GitGetBinPath()
+		if err != nil {
+			return err
+		}
+
+		a.GitBinHash, err = GitGetBinHash(ctx)
+		if err != nil {
+			return err
+		}
+
 		a.Status, err = GitGetStatus(ctx.WorkingDir())
 		if err != nil {
 			return err
 		}
 	} else {
+		a.GitTool = "go-git"
+
 		a.Status, err = GoGitGetStatus(repo)
 		if err != nil {
 			return err

--- a/attestation/git/git.go
+++ b/attestation/git/git.go
@@ -81,7 +81,7 @@ type Tag struct {
 type Attestor struct {
 	GitTool        string               `json:"gittool"`
 	GitBinPath     string               `json:"gitbinpath,omitempty"`
-	GitBinHash     string               `json:"gitbinhash,omitempty"`
+	GitBinHash     cryptoutil.DigestSet `json:"gitbinhash,omitempty"`
 	CommitHash     string               `json:"commithash"`
 	Author         string               `json:"author"`
 	AuthorEmail    string               `json:"authoremail"`

--- a/attestation/git/git_bin.go
+++ b/attestation/git/git_bin.go
@@ -1,0 +1,70 @@
+// Copyright 2023 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+)
+
+// GitExists checks if the git binary is available.
+// This can be used to fall back to go-git implementation.
+func GitExists() bool {
+
+	_, err := exec.LookPath("git")
+	if err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func GitGetStatus(workDir string) (map[string]Status, error) {
+
+	// Execute the git status --porcelain command
+	cmd := exec.Command("git", "-C", workDir, "status", "--porcelain")
+	outputBytes, err := cmd.Output()
+	if err != nil {
+		return map[string]Status{}, err
+	}
+
+	// Convert the output to a string and split into lines
+	output := string(outputBytes)
+	lines := strings.Split(output, "\n")
+
+	// Iterate over the lines and parse the status
+	var gitStatuses map[string]Status = make(map[string]Status)
+	for _, line := range lines {
+		// Skip empty lines
+		if len(line) == 0 {
+			continue
+		}
+
+		// The first two characters are the status codes
+		repoStatus := statusCodeString(git.StatusCode(line[0]))
+		worktreeStatus := statusCodeString(git.StatusCode(line[1]))
+		filePath := strings.TrimSpace(line[2:])
+
+		// Append the parsed status to the list
+		gitStatuses[filePath] = Status{
+			Staging:  repoStatus,
+			Worktree: worktreeStatus,
+		}
+	}
+
+	return gitStatuses, nil
+}

--- a/attestation/git/git_bin.go
+++ b/attestation/git/git_bin.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Witness Contributors
+// Copyright 2024 The Witness Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/attestation/git/git_bin.go
+++ b/attestation/git/git_bin.go
@@ -15,7 +15,6 @@
 package git
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -48,24 +47,22 @@ func GitGetBinPath() (string, error) {
 
 // GitGetBinHash retrieves a sha256 hash of the git binary that is located on the system.
 // The path is determined based on exec.LookPath().
-func GitGetBinHash(ctx *attestation.AttestationContext) (string, error) {
+func GitGetBinHash(ctx *attestation.AttestationContext) (cryptoutil.DigestSet, error) {
 	path, err := exec.LookPath("git")
 	if err != nil {
-		return "", err
+		return cryptoutil.DigestSet{}, err
 	}
 
 	gitBinDigest, err := cryptoutil.CalculateDigestSetFromFile(path, ctx.Hashes())
-	fmt.Printf("%s", gitBinDigest)
 	if err != nil {
-		return "", err
+		return cryptoutil.DigestSet{}, err
 	}
 
-	digestMap, err := gitBinDigest.ToNameMap()
 	if err != nil {
-		return "", err
+		return cryptoutil.DigestSet{}, err
 	}
 
-	return fmt.Sprintf("sha256:%s", digestMap["sha256"]), nil
+	return gitBinDigest, nil
 }
 
 // GitGetStatus retrieves the status of staging and worktree

--- a/schemagen/git.json
+++ b/schemagen/git.json
@@ -4,6 +4,15 @@
   "$defs": {
     "Attestor": {
       "properties": {
+        "gittool": {
+          "type": "string"
+        },
+        "gitbinpath": {
+          "type": "string"
+        },
+        "gitbinhash": {
+          "type": "string"
+        },
         "commithash": {
           "type": "string"
         },
@@ -71,6 +80,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
+        "gittool",
         "commithash",
         "author",
         "authoremail",

--- a/schemagen/git.json
+++ b/schemagen/git.json
@@ -11,7 +11,7 @@
           "type": "string"
         },
         "gitbinhash": {
-          "type": "string"
+          "$ref": "#/$defs/DigestSet"
         },
         "commithash": {
           "type": "string"


### PR DESCRIPTION
## What this PR does / why we need it

By using the native git client its possible to improve the speed significantly.
The default approach is using go-git to no rely on a git client that is installed. But if git is found it will use the git client instead which is much faster compared to the go-git library.

## Which issue(s) this PR fixes (optional)

Fixes https://github.com/in-toto/go-witness/issues/358

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [x] All workflow checks passing (automatically enforced)
- [x] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:

I have large mono repo. For posterity here are the results of a simple run that does not change anything and then with the changes. Basically: `witness run --step build -- echo "hello"`

Repository stats of the working tree.
```shell
$ git count-objects -vH

count: 219
size: 1.13 MiB
in-pack: 2468342
packs: 29
size-pack: 1.36 GiB
prune-packable: 25
garbage: 0
size-garbage: 0 bytes
```

v0.6.0: 82.82s user 96.35s system 63% cpu 4:40.58 total
change: 55.27s user 66.71s system 66% cpu 3:02.30 total