### PR TITLE
feat: adding git remotes to subjects and normalising url

### DIFF
--- a/attestation/git/git_test.go
+++ b/attestation/git/git_test.go
@@ -43,6 +43,25 @@ func TestNameTypeRunType(t *testing.T) {
 	require.Equal(t, RunType, attestor.RunType(), "Expected the attestor's run type")
 }
 
+func TestNormaliseRemotes(t *testing.T) {
+	remotes := []string{
+		"github.com/in-toto/go-witness",
+		"github.com/in-toto/go-witness.git",
+		"https://github.com/in-toto/go-witness",
+		"https://github.com/in-toto/go-witness.git",
+		"git@github.com:in-toto/go-witness",
+		"git@github.com:in-toto/go-witness.git",
+	}
+
+	for _, r := range remotes {
+		nr, err := normaliseRemoteURL(r)
+		require.NoError(t, err, "Expected no error from normaliseRemoteURL")
+
+		require.Equal(t, "github.com/in-toto/go-witness", nr, "normalising failed for %s. Expected 'github.com/in-toto/go-witness', got %s", r, nr)
+	}
+
+}
+
 func TestRunWorksWithCommits(t *testing.T) {
 	attestor := New()
 

--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
+	github.com/whilp/git-urls v1.0.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/zclconf/go-cty v1.14.4 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
## What this PR does / why we need it

Description

This PR adds the repository remotes to the subjects of the in-toto statement for more easy querying of understanding the identity of a repository. It also normalises the remote url, in an attempt to make it agnostic to the protocol used in that config to connect to the remote (e.g., `http://` / `ssh`).