### PR TITLE
fix: --dirhash-glob fails with symlinked directories (#442)

### DIFF
--- a/attestation/file/file_test.go
+++ b/attestation/file/file_test.go
@@ -97,3 +97,36 @@ func TestDirHash(t *testing.T) {
 
 	require.Equal(t, dirDigestSetMap["dirHash"], dirHashSha256)
 }
+
+func TestDirHashWithSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a directory structure with symlinks
+	testDir := filepath.Join(dir, "testdir")
+	require.NoError(t, os.Mkdir(testDir, os.ModePerm))
+	testDir2 := filepath.Join(testDir, "testdir2")
+	require.NoError(t, os.Mkdir(testDir2, os.ModePerm))
+	symlinkDir := filepath.Join(testDir, "symlinkdir")
+	require.NoError(t, os.Symlink(testDir2, symlinkDir))
+
+	dirHashGlobs := make([]glob.Glob, 0)
+	dirHash := "testdir"
+	dirHashGlobItem, _ := glob.Compile(dirHash)
+	dirHashGlobs = append(dirHashGlobs, dirHashGlobItem)
+
+	artifacts, err := RecordArtifacts(dir, map[string]cryptoutil.DigestSet{}, []cryptoutil.DigestValue{{Hash: crypto.SHA256}}, map[string]struct{}{}, false, map[string]bool{}, dirHashGlobs)
+	require.NoError(t, err)
+
+	// Below command is example usage on the above created scenario for testdir.
+	// find . -type f | cut -c3- | LC_ALL=C sort | xargs -r sha256sum | sha256sum
+	dirHashSha256 := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	require.Len(t, artifacts, 1) // testdir/
+
+	// The original directory path should be used in the artifacts map
+	dirDigestSet := artifacts["testdir/"]
+	dirDigestSetMap, err := dirDigestSet.ToNameMap()
+	require.NoError(t, err)
+
+	require.Equal(t, dirDigestSetMap["dirHash"], dirHashSha256)
+}


### PR DESCRIPTION
## What this PR does / why we need it

Description

Handle the case where the dirHash option is used and the dirHash matched folders contain symlinks.

## Which issue(s) this PR fixes (optional)

Fixes #442.

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
