### PR TITLE
Add ability to control command run process outputs

### DIFF
--- a/attestation/commandrun/commandrun.go
+++ b/attestation/commandrun/commandrun.go
@@ -161,6 +161,11 @@ func (r *CommandRun) runCmd(ctx *attestation.AttestationContext) error {
 	stderrBuffer := bytes.Buffer{}
 	stdoutWriters := []io.Writer{&stdoutBuffer}
 	stderrWriters := []io.Writer{&stderrBuffer}
+	if ctx.OutputWriters() != nil {
+		stdoutWriters = append(stdoutWriters, ctx.OutputWriters()...)
+		stderrWriters = append(stderrWriters, ctx.OutputWriters()...)
+	}
+
 	if !r.silent {
 		stdoutWriters = append(stdoutWriters, os.Stdout)
 		stderrWriters = append(stderrWriters, os.Stderr)

--- a/attestation/context.go
+++ b/attestation/context.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -62,6 +63,12 @@ func (e ErrAttestor) Error() string {
 }
 
 type AttestationContextOption func(ctx *AttestationContext)
+
+func WithOutputWriters(w []io.Writer) AttestationContextOption {
+	return func(ctx *AttestationContext) {
+		ctx.outputWriters = w
+	}
+}
 
 func WithContext(ctx context.Context) AttestationContextOption {
 	return func(actx *AttestationContext) {
@@ -138,6 +145,7 @@ type AttestationContext struct {
 	stepName            string
 	mutex               sync.RWMutex
 	environmentCapturer *environment.Capture
+	outputWriters       []io.Writer
 }
 
 type Product struct {
@@ -245,6 +253,10 @@ func (ctx *AttestationContext) runAttestor(attestor Attestor) {
 	}
 
 	log.Infof("Finished %v attestor... (%vs)", attestor.Name(), time.Since(startTime).Seconds())
+}
+
+func (ctx *AttestationContext) OutputWriters() []io.Writer {
+	return ctx.outputWriters
 }
 
 func (ctx *AttestationContext) DirHashGlob() []glob.Glob {


### PR DESCRIPTION
## What this PR does / why we need it

Allow customizing destination of `go-witness` output. This is useful for storing logs and better integrating the library into systems without `stdout` capabilities. 
