### PR TITLE
Docker attestor refactor

### DIFF
--- a/attestation/context.go
+++ b/attestation/context.go
@@ -230,6 +230,7 @@ func (ctx *AttestationContext) runAttestor(attestor Attestor) {
 			Error:     err,
 		})
 		ctx.mutex.Unlock()
+		return
 	}
 
 	ctx.mutex.Lock()

--- a/attestation/context.go
+++ b/attestation/context.go
@@ -161,13 +161,14 @@ func NewContext(stepName string, attestors []Attestor, opts ...AttestationContex
 	}
 
 	ctx := &AttestationContext{
-		ctx:        context.Background(),
-		attestors:  attestors,
-		workingDir: wd,
-		hashes:     []cryptoutil.DigestValue{{Hash: crypto.SHA256}, {Hash: crypto.SHA256, GitOID: true}, {Hash: crypto.SHA1, GitOID: true}},
-		materials:  make(map[string]cryptoutil.DigestSet),
-		products:   make(map[string]Product),
-		stepName:   stepName,
+		ctx:                 context.Background(),
+		attestors:           attestors,
+		workingDir:          wd,
+		hashes:              []cryptoutil.DigestValue{{Hash: crypto.SHA256}, {Hash: crypto.SHA256, GitOID: true}, {Hash: crypto.SHA1, GitOID: true}},
+		materials:           make(map[string]cryptoutil.DigestSet),
+		products:            make(map[string]Product),
+		stepName:            stepName,
+		environmentCapturer: environment.New(),
 	}
 
 	for _, opt := range opts {
@@ -201,12 +202,11 @@ func (ctx *AttestationContext) RunAttestors() error {
 		log.Infof("Starting %s attestors stage...", k.String())
 
 		var wg sync.WaitGroup
-		ch := make(chan int, len(attestors))
 
 		for _, att := range attestors[k] {
 			wg.Add(1)
 			go func(att Attestor) {
-				defer func() { wg.Done(); <-ch }()
+				defer wg.Done()
 				ctx.runAttestor(att)
 			}(att)
 		}

--- a/attestation/docker/docker.go
+++ b/attestation/docker/docker.go
@@ -200,7 +200,7 @@ func (a *Attestor) getDockerCandidate(ctx *attestation.AttestationContext) (*doc
 	for path, product := range products {
 		if strings.Contains(jsonMimeType, product.MimeType) {
 			var met docker.BuildInfo
-			f, err := os.ReadFile(path)
+			f, err := os.ReadFile(filepath.Join(ctx.WorkingDir(), path))
 			if err != nil {
 				return nil, fmt.Errorf("failed to read file %s: %w", path, err)
 			}

--- a/attestation/docker/docker.go
+++ b/attestation/docker/docker.go
@@ -178,22 +178,6 @@ func (a *Attestor) setDockerCandidate(met *docker.BuildInfo) error {
 	return nil
 }
 
-func (a *Attestor) getImageDigestFileCandidate(ctx *attestation.AttestationContext) (string, error) {
-	products := ctx.Products()
-
-	for path, product := range products {
-		if strings.Contains(sha256MimeType, product.MimeType) {
-			f, err := os.ReadFile(filepath.Join(ctx.WorkingDir(), path))
-			if err != nil {
-				return "", fmt.Errorf("failed to read file %s: %w", path, err)
-			}
-			return string(f), nil
-		}
-	}
-
-	return "", nil
-}
-
 func (a *Attestor) getDockerCandidates(ctx *attestation.AttestationContext) ([]docker.BuildInfo, error) {
 	products := ctx.Products()
 

--- a/attestation/docker/docker_test.go
+++ b/attestation/docker/docker_test.go
@@ -16,9 +16,8 @@ package docker
 
 import (
 	"crypto"
-	"encoding/base64"
-
 	"crypto/sha1"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"testing"
@@ -42,53 +41,8 @@ func Test_DockerAttestor(t *testing.T) {
 				"ewogICJidWlsZHguYnVpbGQucHJvdmVuYW5jZS9saW51eC9hbWQ2NCI6IHsKICAgICJidWlsZFR5cGUiOiAiaHR0cHM6Ly9tb2J5cHJvamVjdC5vcmcvYnVpbGRraXRAdjEiLAogICAgIm1hdGVyaWFscyI6IFsKICAgICAgewogICAgICAgICJ1cmkiOiAicGtnOmRvY2tlci91YnVudHVAbGF0ZXN0P3BsYXRmb3JtPWxpbnV4JTJGYW1kNjQiLAogICAgICAgICJkaWdlc3QiOiB7CiAgICAgICAgICAic2hhMjU2IjogIjcyMjk3ODQ4NDU2ZDVkMzdkMTI2MjYzMDEwOGFiMzA4ZDNlOWVjN2VkMWMzMjg2YTMyZmUwOTg1NjYxOWE3ODIiCiAgICAgICAgfQogICAgICB9CiAgICBdLAogICAgImludm9jYXRpb24iOiB7CiAgICAgICJjb25maWdTb3VyY2UiOiB7fSwKICAgICAgInBhcmFtZXRlcnMiOiB7CiAgICAgICAgImZyb250ZW5kIjogImRvY2tlcmZpbGUudjAiLAogICAgICAgICJsb2NhbHMiOiBbCiAgICAgICAgICB7CiAgICAgICAgICAgICJuYW1lIjogImNvbnRleHQiCiAgICAgICAgICB9LAogICAgICAgICAgewogICAgICAgICAgICAibmFtZSI6ICJkb2NrZXJmaWxlIgogICAgICAgICAgfQogICAgICAgIF0KICAgICAgfSwKICAgICAgImVudmlyb25tZW50IjogewogICAgICAgICJwbGF0Zm9ybSI6ICJsaW51eC9hcm02NCIKICAgICAgfQogICAgfQogIH0sCiAgImJ1aWxkeC5idWlsZC5wcm92ZW5hbmNlL2xpbnV4L2FybTY0IjogewogICAgImJ1aWxkVHlwZSI6ICJodHRwczovL21vYnlwcm9qZWN0Lm9yZy9idWlsZGtpdEB2MSIsCiAgICAibWF0ZXJpYWxzIjogWwogICAgICB7CiAgICAgICAgInVyaSI6ICJwa2c6ZG9ja2VyL3VidW50dUBsYXRlc3Q/cGxhdGZvcm09bGludXglMkZhcm02NCIsCiAgICAgICAgImRpZ2VzdCI6IHsKICAgICAgICAgICJzaGEyNTYiOiAiNzIyOTc4NDg0NTZkNWQzN2QxMjYyNjMwMTA4YWIzMDhkM2U5ZWM3ZWQxYzMyODZhMzJmZTA5ODU2NjE5YTc4MiIKICAgICAgICB9CiAgICAgIH0KICAgIF0sCiAgICAiaW52b2NhdGlvbiI6IHsKICAgICAgImNvbmZpZ1NvdXJjZSI6IHt9LAogICAgICAicGFyYW1ldGVycyI6IHsKICAgICAgICAiZnJvbnRlbmQiOiAiZG9ja2VyZmlsZS52MCIsCiAgICAgICAgImxvY2FscyI6IFsKICAgICAgICAgIHsKICAgICAgICAgICAgIm5hbWUiOiAiY29udGV4dCIKICAgICAgICAgIH0sCiAgICAgICAgICB7CiAgICAgICAgICAgICJuYW1lIjogImRvY2tlcmZpbGUiCiAgICAgICAgICB9CiAgICAgICAgXQogICAgICB9LAogICAgICAiZW52aXJvbm1lbnQiOiB7CiAgICAgICAgInBsYXRmb3JtIjogImxpbnV4L2FybTY0IgogICAgICB9CiAgICB9CiAgfSwKICAiYnVpbGR4LmJ1aWxkLnJlZiI6ICJzdHJhbmdlX2xhbGFuZGUvc3RyYW5nZV9sYWxhbmRlMC9rNzVnemk1OHQ4eW1xemtzbmFkb3dvN3p5Igp9",
 			},
 			validate: func(a *Attestor, err error, name string) {
-
-				require.Empty(t, a.ImageDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}], a.ImageReferences, "TestName: %s", name)
-				require.Equal(t, []string{""}, a.ImageReferences, "TestName: %s", name)
-				require.Equal(t, []Material{{
-					Architecture: "linux/arm64",
-					URI:          "pkg:docker/ubuntu@latest?platform=linux%2Farm64",
-					Digest: cryptoutil.DigestSet{
-						cryptoutil.DigestValue{
-							Hash:    crypto.SHA256,
-							GitOID:  false,
-							DirHash: false}: "72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782",
-					},
-				}}, a.Materials["linux/arm64"], "TestName: %s", name)
-
-				require.Equal(t, []Material{{
-					Architecture: "linux/amd64",
-					URI:          "pkg:docker/ubuntu@latest?platform=linux%2Famd64",
-					Digest: cryptoutil.DigestSet{
-						cryptoutil.DigestValue{
-							Hash:    crypto.SHA256,
-							GitOID:  false,
-							DirHash: false}: "72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782",
-					},
-				}}, a.Materials["linux/amd64"], "TestName: %s", name)
-
-				require.NoError(t, err, "TestName: %s", name)
-			},
-		},
-		{
-			name: "ValidMetadataFileWithSinglePlatform",
-			testProducts: []string{
-				"ewogICJidWlsZHguYnVpbGQucHJvdmVuYW5jZSI6IHsKICAgICJidWlsZFR5cGUiOiAiaHR0cHM6Ly9tb2J5cHJvamVjdC5vcmcvYnVpbGRraXRAdjEiLAogICAgIm1hdGVyaWFscyI6IFsKICAgICAgewogICAgICAgICJ1cmkiOiAicGtnOmRvY2tlci9hbHBpbmVAbGF0ZXN0P3BsYXRmb3JtPWxpbnV4JTJGYW1kNjQiLAogICAgICAgICJkaWdlc3QiOiB7CiAgICAgICAgICAic2hhMjU2IjogImE4NTYwYjM2ZThiODIxMDYzNGY3N2Q5ZjdmOWVmZDdmZmE0NjNlMzgwYjc1ZTJlNzRhZmY0NTExZGYzZWY4OGMiCiAgICAgICAgfQogICAgICB9CiAgICBdLAogICAgImludm9jYXRpb24iOiB7CiAgICAgICJjb25maWdTb3VyY2UiOiB7fSwKICAgICAgInBhcmFtZXRlcnMiOiB7CiAgICAgICAgImZyb250ZW5kIjogImRvY2tlcmZpbGUudjAiLAogICAgICAgICJsb2NhbHMiOiBbCiAgICAgICAgICB7CiAgICAgICAgICAgICJuYW1lIjogImNvbnRleHQiCiAgICAgICAgICB9LAogICAgICAgICAgewogICAgICAgICAgICAibmFtZSI6ICJkb2NrZXJmaWxlIgogICAgICAgICAgfQogICAgICAgIF0KICAgICAgfSwKICAgICAgImVudmlyb25tZW50IjogewogICAgICAgICJwbGF0Zm9ybSI6ICJsaW51eC9hcm02NCIKICAgICAgfQogICAgfQogIH0sCiAgImJ1aWxkeC5idWlsZC5yZWYiOiAic3RyYW5nZV9sYWxhbmRlL3N0cmFuZ2VfbGFsYW5kZTAva3N0dTd0OHJieHFyenY0dWV1NmVpanNmayIKfQ==",
-			},
-			validate: func(a *Attestor, err error, name string) {
-				require.Empty(t, a.ImageDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}], "TestName: %s", name)
-				require.Equal(t, []Material{{
-					Architecture: "linux/amd64",
-					URI:          "pkg:docker/alpine@latest?platform=linux%2Famd64",
-					Digest: cryptoutil.DigestSet{
-						cryptoutil.DigestValue{
-							Hash:    crypto.SHA256,
-							GitOID:  false,
-							DirHash: false}: "a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c",
-					},
-				}}, a.Materials["linux/amd64"], "TestName: %s", name)
-
-				require.NoError(t, err, "TestName: %s", name)
+				require.Equal(t, a.Products, map[string]DockerProduct{}, "TestName: %s", name)
+				require.ErrorContains(t, err, "no products to attest", "TestName: %s", name)
 			},
 		},
 		{
@@ -97,8 +51,8 @@ func Test_DockerAttestor(t *testing.T) {
 				"ewogICJidWlsZHguYnVpbGQucmVmIjogInN0cmFuZ2VfbGFsYW5kZS9zdHJhbmdlX2xhbGFuZGUwL2x0eDE2ZTRybnl1MHhwMDc3N29ybWFybXoiLAogICJjb250YWluZXJpbWFnZS5kZXNjcmlwdG9yIjogewogICAgIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLmluZGV4LnYxK2pzb24iLAogICAgImRpZ2VzdCI6ICJzaGEyNTY6NGJlZTAzOTY0MWNlMzAwY2IxZDQ2YTVkMThlMDYxMjVhNzBlYjcwYzM1MWVmNjE2YjZlNDlkNzhiN2RlZjU1ZCIsCiAgICAic2l6ZSI6IDE2MDkKICB9LAogICJjb250YWluZXJpbWFnZS5kaWdlc3QiOiAic2hhMjU2OjRiZWUwMzk2NDFjZTMwMGNiMWQ0NmE1ZDE4ZTA2MTI1YTcwZWI3MGMzNTFlZjYxNmI2ZTQ5ZDc4YjdkZWY1NWQiLAogICJpbWFnZS5uYW1lIjogImdoY3IuaW8vY2hhb3NpbnRoZWNyZC9taWMtdGVzdDpsYXRlc3QiCn0=",
 			},
 			validate: func(a *Attestor, err error, name string) {
-				require.Equal(t, "4bee039641ce300cb1d46a5d18e06125a70eb70c351ef616b6e49d78b7def55d", a.ImageDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}], "TestName: %s", name)
-				require.Equal(t, []string{"ghcr.io/chaosinthecrd/mic-test:latest"}, a.ImageReferences, "TestName: %s", name)
+				require.Equal(t, "4bee039641ce300cb1d46a5d18e06125a70eb70c351ef616b6e49d78b7def55d", a.Products["4bee039641ce300cb1d46a5d18e06125a70eb70c351ef616b6e49d78b7def55d"].ImageDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}], "TestName: %s", name)
+				require.Equal(t, []string{"ghcr.io/chaosinthecrd/mic-test:latest"}, a.Products["4bee039641ce300cb1d46a5d18e06125a70eb70c351ef616b6e49d78b7def55d"].ImageReferences, "TestName: %s", name)
 				require.NoError(t, err, "TestName: %s", name)
 			},
 		},
@@ -108,9 +62,8 @@ func Test_DockerAttestor(t *testing.T) {
 				"ewogICJib21Gb3JtYXQiOiAiQ3ljbG9uZURYIiwKICAic3BlY1ZlcnNpb24iOiAiMS40IiwKICAidmVyc2lvbiI6IDEsCiAgIm1ldGFkYXRhIjogewogICAgImNvbXBvbmVudCI6IHsKICAgICAgImJvbS1yZWYiOiAicGtnOmdvbGFuZy9naXRodWIuY29tL2NoYW9zaW50aGVjcmQvbWljLXRlc3RAKGRldmVsKT90eXBlPW1vZHVsZSIsCiAgICAgICJ0eXBlIjogImFwcGxpY2F0aW9uIiwKICAgICAgIm5hbWUiOiAiZ2l0aHViLmNvbS9jaGFvc2ludGhlY3JkL21pYy10ZXN0IiwKICAgICAgInZlcnNpb24iOiAiKGRldmVsKSIsCiAgICAgICJwdXJsIjogInBrZzpnb2xhbmcvZ2l0aHViLmNvbS9jaGFvc2ludGhlY3JkL21pYy10ZXN0QChkZXZlbCk/dHlwZT1tb2R1bGUiLAogICAgICAiZXh0ZXJuYWxSZWZlcmVuY2VzIjogWwogICAgICAgIHsKICAgICAgICAgICJ1cmwiOiAiaHR0cHM6Ly9naXRodWIuY29tL2NoYW9zaW50aGVjcmQvbWljLXRlc3QiLAogICAgICAgICAgInR5cGUiOiAidmNzIgogICAgICAgIH0KICAgICAgXQogICAgfSwKICAgICJwcm9wZXJ0aWVzIjogWwogICAgICB7CiAgICAgICAgIm5hbWUiOiAiY2R4OmdvbW9kOmJpbmFyeTpuYW1lIiwKICAgICAgICAidmFsdWUiOiAib3V0IgogICAgICB9CiAgICBdCiAgfSwKICAiZGVwZW5kZW5jaWVzIjogWwogICAgewogICAgICAicmVmIjogInBrZzpnb2xhbmcvZ2l0aHViLmNvbS9jaGFvc2ludGhlY3JkL21pYy10ZXN0QChkZXZlbCk/dHlwZT1tb2R1bGUiCiAgICB9CiAgXSwKICAiY29tcG9zaXRpb25zIjogWwogICAgewogICAgICAiYWdncmVnYXRlIjogImNvbXBsZXRlIiwKICAgICAgImRlcGVuZGVuY2llcyI6IFsKICAgICAgICAicGtnOmdvbGFuZy9naXRodWIuY29tL2NoYW9zaW50aGVjcmQvbWljLXRlc3RAKGRldmVsKT90eXBlPW1vZHVsZSIKICAgICAgXQogICAgfSwKICAgIHsKICAgICAgImFnZ3JlZ2F0ZSI6ICJ1bmtub3duIgogICAgfQogIF0KfQo=",
 			},
 			validate: func(a *Attestor, err error, name string) {
-				require.Equal(t, a.ImageDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}], "", "TestName: %s", name)
-				require.Equal(t, []string{""}, a.ImageReferences, "TestName: %s", name)
-				require.NoError(t, err, "TestName: %s", name)
+				require.Equal(t, a.Products, map[string]DockerProduct{}, "TestName: %s", name)
+				require.Error(t, err, "TestName: %s", name)
 			},
 		},
 	}
@@ -129,6 +82,7 @@ func Test_DockerAttestor(t *testing.T) {
 				require.NoError(t, err)
 
 				file := SetupTest(t, prod)
+				defer os.Remove(file.Name())
 
 				testProductSet[file.Name()] = attestation.Product{
 					MimeType: "application/json",
@@ -142,8 +96,17 @@ func Test_DockerAttestor(t *testing.T) {
 			require.NoError(t, err)
 
 			err = ctx.RunAttestors()
+			require.NoError(t, err)
 
-			tt.validate(a, err, tt.name)
+			ca := ctx.CompletedAttestors()
+			var dockerErr error
+			for _, a := range ca {
+				if a.Attestor.Type() == Type {
+					dockerErr = a.Error
+				}
+			}
+
+			tt.validate(a, dockerErr, tt.name)
 
 			for prod := range tp.Products() {
 				os.Remove(prod)

--- a/attestation/docker/docker_test.go
+++ b/attestation/docker/docker_test.go
@@ -157,7 +157,7 @@ func SetupTest(t *testing.T, productFileData string) *os.File {
 	s.Write([]byte(productFileData))
 	bs := s.Sum(nil)
 
-	file, err := os.CreateTemp("", fmt.Sprintf("%x.json", bs))
+	file, err := os.CreateTemp("./", fmt.Sprintf("%x.json", bs))
 	require.NoError(t, err)
 
 	decoded, err := base64.StdEncoding.DecodeString(productFileData)

--- a/attestation/gitlab/gitlab.go
+++ b/attestation/gitlab/gitlab.go
@@ -117,7 +117,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	a.CIServerUrl = os.Getenv("CI_SERVER_URL")
 	jwksUrl := fmt.Sprintf("%s/oauth/discovery/keys", a.CIServerUrl)
-	jwtString := os.Getenv("ID_TOKEN")
+	jwtString := os.Getenv("CI_JOB_TOKEN")
 	if jwtString != "" {
 		a.JWT = jwt.New(jwt.WithToken(jwtString), jwt.WithJWKSUrl(jwksUrl))
 		if err := a.JWT.Attest(ctx); err != nil {

--- a/attestation/gitlab/gitlab.go
+++ b/attestation/gitlab/gitlab.go
@@ -69,6 +69,8 @@ func (e ErrNotGitlab) Error() string {
 	return "not in a gitlab ci job"
 }
 
+type Option func(a *Attestor)
+
 type Attestor struct {
 	JWT          *jwt.Attestor `json:"jwt,omitempty"`
 	CIConfigPath string        `json:"ciconfigpath"`
@@ -84,10 +86,30 @@ type Attestor struct {
 	RunnerID     string        `json:"runnerid"`
 	CIHost       string        `json:"cihost"`
 	CIServerUrl  string        `json:"ciserverurl"`
+	token        string
+	tokenEnvVar  string
 }
 
-func New() *Attestor {
-	return &Attestor{}
+func WithToken(token string) Option {
+	return func(a *Attestor) {
+		a.token = token
+	}
+}
+
+func WithTokenEnvVar(envVar string) Option {
+	return func(a *Attestor) {
+		a.tokenEnvVar = envVar
+	}
+}
+
+func New(opts ...Option) *Attestor {
+	a := &Attestor{}
+
+	for _, opt := range opts {
+		opt(a)
+	}
+
+	return a
 }
 
 func (a *Attestor) Name() string {
@@ -117,7 +139,17 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	a.CIServerUrl = os.Getenv("CI_SERVER_URL")
 	jwksUrl := fmt.Sprintf("%s/oauth/discovery/keys", a.CIServerUrl)
-	jwtString := os.Getenv("CI_JOB_TOKEN")
+
+	var jwtString string
+	if a.token != "" {
+		jwtString = a.token
+	} else if a.tokenEnvVar != "" {
+		jwtString = os.Getenv(a.tokenEnvVar)
+	} else {
+		// Only works in GitLab < 17.0
+		jwtString = os.Getenv("CI_JOB_JWT")
+	}
+
 	if jwtString != "" {
 		a.JWT = jwt.New(jwt.WithToken(jwtString), jwt.WithJWKSUrl(jwksUrl))
 		if err := a.JWT.Attest(ctx); err != nil {

--- a/internal/docker/metadata.go
+++ b/internal/docker/metadata.go
@@ -117,11 +117,25 @@ func (b *BuildInfo) UnmarshalJSON(data []byte) error {
 
 				if key == "buildx.build.provenance" {
 					for _, mat := range provenance.Materials {
-						if parts := strings.Split(mat.URI, "?platform="); len(parts) == 2 {
-							arch, err = url.QueryUnescape(parts[1])
-							if err != nil {
-								continue
-							}
+						raw := strings.ReplaceAll(mat.URI, `\u0026`, "&")
+						parsed, err := url.Parse(raw)
+						if err != nil {
+							continue
+						}
+
+						queryParams, err := url.ParseQuery(parsed.RawQuery)
+						if err != nil {
+							continue
+						}
+
+						platform := queryParams.Get("platform")
+						if platform == "" {
+							continue
+						}
+
+						arch, err = url.QueryUnescape(platform)
+						if err != nil {
+							continue
 						}
 					}
 				} else {

--- a/run.go
+++ b/run.go
@@ -35,6 +35,7 @@ type runOptions struct {
 	attestationOpts []attestation.AttestationContextOption
 	timestampers    []timestamp.Timestamper
 	insecure        bool
+	ignoreErrors    bool
 }
 
 type RunOption func(ro *runOptions)
@@ -44,6 +45,13 @@ type RunOption func(ro *runOptions)
 func RunWithInsecure(insecure bool) RunOption {
 	return func(ro *runOptions) {
 		ro.insecure = insecure
+	}
+}
+
+// RunWithIgnoreErrors will ignore any errors that occur during the execution of the attestors
+func RunWithIgnoreErrors(ignoreErrors bool) RunOption {
+	return func(ro *runOptions) {
+		ro.ignoreErrors = ignoreErrors
 	}
 }
 
@@ -104,8 +112,9 @@ func RunWithExports(stepName string, opts ...RunOption) ([]RunResult, error) {
 
 func run(stepName string, opts []RunOption) ([]RunResult, error) {
 	ro := runOptions{
-		stepName: stepName,
-		insecure: false,
+		stepName:     stepName,
+		insecure:     false,
+		ignoreErrors: false,
 	}
 
 	for _, opt := range opts {
@@ -147,7 +156,7 @@ func run(stepName string, opts []RunOption) ([]RunResult, error) {
 		}
 	}
 
-	if len(errs) > 0 {
+	if !ro.ignoreErrors && len(errs) > 0 {
 		errs := append([]error{errors.New("attestors failed with error messages")}, errs...)
 		return result, errors.Join(errs...)
 	}

--- a/schemagen/docker.json
+++ b/schemagen/docker.json
@@ -4,6 +4,27 @@
   "$defs": {
     "Attestor": {
       "properties": {
+        "products": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DockerProduct"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "products"
+      ]
+    },
+    "DigestSet": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "DockerProduct": {
+      "properties": {
         "materials": {
           "additionalProperties": {
             "items": {
@@ -30,12 +51,6 @@
         "imagereferences",
         "imagedigest"
       ]
-    },
-    "DigestSet": {
-      "additionalProperties": {
-        "type": "string"
-      },
-      "type": "object"
     },
     "Material": {
       "properties": {


### PR DESCRIPTION
## What this PR does / why we need it

Description

This PR introduces:
- a run option to allow for errors to be ignored
- a refactor of the docker attestor to allow the metadata of multiple container images to be stored in the predicate
- some minor bug fixes found after merge of the attestor
- a minor fix in the way we are parsing the architecture from the material URI in the docker metadata file.