### PR TITLE
ci: add witness build integration and workflow improvements

### DIFF
--- a/.github/workflows/build-witness-test.yml
+++ b/.github/workflows/build-witness-test.yml
@@ -1,0 +1,29 @@
+name: Build Witness CLI Test
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  build-witness:
+    name: Build Witness CLI with local code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Build Witness CLI with local code
+        run: |
+          # In CI we'll use the checked out copy of go-witness
+          make build-witness GO_WITNESS_PATH=$GITHUB_WORKSPACE
+          
+          # List available attestors
+          echo "Available attestors:"
+          /tmp/witness-build-test/witness attestors list

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,46 @@ test: ## Run the go unit tests
 schema: ## Generate the attestor schema json files
 	go run ./schemagen/schema.go
 
+WITNESS_TMP_DIR := /tmp/witness-build-test
+CURRENT_SHA := $(shell git rev-parse HEAD)
+CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GO_WITNESS_MODULE := github.com/in-toto/go-witness
+GO_WITNESS_PATH ?= $(shell pwd)
+
+.PHONY: build-witness
+build-witness: ## Build the witness CLI using local go-witness code (or SHA in CI)
+	# Usage: make build-witness GO_WITNESS_PATH=/path/to/go-witness (defaults to current dir)
+	@echo "Using go-witness SHA: $(CURRENT_SHA)"
+	@echo "Current branch: $(CURRENT_BRANCH)"
+	
+	# Create clean temporary directory
+	rm -rf $(WITNESS_TMP_DIR)
+	mkdir -p $(WITNESS_TMP_DIR)
+	
+	# Clone witness repository
+	git clone https://github.com/in-toto/witness.git $(WITNESS_TMP_DIR)
+	
+	# Update go-witness dependency to use local code
+	cd $(WITNESS_TMP_DIR) && \
+		go mod edit -replace $(GO_WITNESS_MODULE)=$(GO_WITNESS_PATH) && \
+		go mod tidy
+	
+	# Build witness
+	cd $(WITNESS_TMP_DIR) && \
+		go build -o witness .
+	
+	@echo "Witness successfully built with go-witness SHA: $(CURRENT_SHA)"
+	@echo "Binary located at: $(WITNESS_TMP_DIR)/witness"
+	
+	# Verify the binary works
+	$(WITNESS_TMP_DIR)/witness version
+	@echo "Available attestors:"
+	$(WITNESS_TMP_DIR)/witness attestors list
+
+.PHONY: clean-witness
+clean-witness: ## Clean up witness build environment
+	rm -rf $(WITNESS_TMP_DIR)
+
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 

--- a/ci-build-witness.mk
+++ b/ci-build-witness.mk
@@ -1,0 +1,36 @@
+# Makefile to build witness CLI using current go-witness PR SHA
+.PHONY: build-witness clean
+
+WITNESS_TMP_DIR := /tmp/witness-build-test
+CURRENT_SHA := $(shell git rev-parse HEAD)
+CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+GO_WITNESS_MODULE := github.com/in-toto/go-witness
+
+build-witness:
+	@echo "Using go-witness SHA: $(CURRENT_SHA)"
+	@echo "Current branch: $(CURRENT_BRANCH)"
+	
+	# Create clean temporary directory
+	rm -rf $(WITNESS_TMP_DIR)
+	mkdir -p $(WITNESS_TMP_DIR)
+	
+	# Clone witness repository
+	git clone https://github.com/in-toto/witness.git $(WITNESS_TMP_DIR)
+	
+	# Update go-witness dependency to use our current SHA
+	cd $(WITNESS_TMP_DIR) && \
+		go get $(GO_WITNESS_MODULE)@$(CURRENT_SHA) && \
+		go mod tidy
+	
+	# Build witness
+	cd $(WITNESS_TMP_DIR) && \
+		go build -o witness .
+	
+	@echo "Witness successfully built with go-witness SHA: $(CURRENT_SHA)"
+	@echo "Binary located at: $(WITNESS_TMP_DIR)/witness"
+	
+	# Verify the binary works
+	$(WITNESS_TMP_DIR)/witness version
+
+clean:
+	rm -rf $(WITNESS_TMP_DIR)


### PR DESCRIPTION
## Summary
- Adds makefile targets for building witness CLI with local go-witness code
- Integrates witness build targets into main Makefile for easier discovery
- Adds workflow for testing the build process
- Displays available attestors after build for verification

## Test plan
- Build witness CLI using the new makefile targets
- Verify the workflow runs successfully