### PR TITLE
chore: added the ability to attest node information

### DIFF
--- a/schemagen/k8smanifest.json
+++ b/schemagen/k8smanifest.json
@@ -50,12 +50,67 @@
       "properties": {
         "server": {
           "type": "string"
+        },
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/RecordedNode"
+          },
+          "type": "object"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "server"
+        "server",
+        "nodes"
+      ]
+    },
+    "NodeSystemInfo": {
+      "properties": {
+        "machineID": {
+          "type": "string"
+        },
+        "systemUUID": {
+          "type": "string"
+        },
+        "bootID": {
+          "type": "string"
+        },
+        "kernelVersion": {
+          "type": "string"
+        },
+        "osImage": {
+          "type": "string"
+        },
+        "containerRuntimeVersion": {
+          "type": "string"
+        },
+        "kubeletVersion": {
+          "type": "string"
+        },
+        "kubeProxyVersion": {
+          "type": "string"
+        },
+        "operatingSystem": {
+          "type": "string"
+        },
+        "architecture": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "machineID",
+        "systemUUID",
+        "bootID",
+        "kernelVersion",
+        "osImage",
+        "containerRuntimeVersion",
+        "kubeletVersion",
+        "kubeProxyVersion",
+        "operatingSystem",
+        "architecture"
       ]
     },
     "RecordedImage": {
@@ -75,6 +130,29 @@
       "required": [
         "reference",
         "digest"
+      ]
+    },
+    "RecordedNode": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "nodeInfo": {
+          "$ref": "#/$defs/NodeSystemInfo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "labels",
+        "nodeInfo"
       ]
     },
     "RecordedObject": {


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds to the k8smanifest attestor to parse node manifests and store information about each node in the predicate
