### PR TITLE
feat(attestation): adds aws codebuild attestor

### DIFF
--- a/attestation/aws-codebuild/README.md
+++ b/attestation/aws-codebuild/README.md
@@ -1,0 +1,45 @@
+# AWS CodeBuild Attestor
+
+This attestor captures AWS CodeBuild metadata and provenance when witness is used within AWS CodeBuild CI/CD pipelines. It collects information about the build, project, source code, and other AWS CodeBuild-specific metadata to provide a verifiable record of the build environment.
+
+## Usage
+
+To use the AWS CodeBuild attestor, include it in your witness invocation:
+
+```bash
+witness run \
+  --attestor aws-codebuild \
+  --attestor git \
+  --attestor material \
+  --signer <your-signer> \
+  --out attestation.json \
+  -- <your-build-command>
+```
+
+## Environment Variables
+
+The attestor uses the following AWS CodeBuild environment variables:
+
+- `CODEBUILD_BUILD_ID`: The CodeBuild ID for the build
+- `CODEBUILD_BUILD_ARN`: The ARN of the build
+- `CODEBUILD_BUILD_NUMBER`: The build number
+- `CODEBUILD_PROJECT_NAME`: The name of the project being built
+- `CODEBUILD_INITIATOR`: The entity that started the build
+- `CODEBUILD_RESOLVED_SOURCE_VERSION`: The commit ID for the version of source code being built
+- `CODEBUILD_SOURCE_REPO_URL`: The URL to the source code repository
+- `CODEBUILD_BATCH_BUILD_IDENTIFIER`: Identifier if part of a batch build
+- `CODEBUILD_WEBHOOK_EVENT`: For webhook triggered builds, the webhook event type
+- `CODEBUILD_WEBHOOK_HEAD_REF`: For webhook triggered builds, the head reference
+- `CODEBUILD_WEBHOOK_ACTOR_ACCOUNT_ID`: For webhook triggered builds, the actor's account ID
+
+## Additional API Data
+
+If AWS credentials and permissions are available, the attestor will also make an API call to fetch additional build details from the AWS CodeBuild API using `BatchGetBuilds`.
+
+## Subjects
+
+The attestor creates the following subjects, which can be used for policy verification and traceability:
+
+- `codebuild-build-id:<build-id>`: The CodeBuild build ID
+- `codebuild-project:<project>`: The CodeBuild project name
+- `codebuild-source-version:<commit>`: The commit ID of the source code being built

--- a/attestation/aws-codebuild/aws-codebuild.go
+++ b/attestation/aws-codebuild/aws-codebuild.go
@@ -1,0 +1,236 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws_codebuild
+
+import (
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/codebuild"
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/log"
+	"github.com/invopop/jsonschema"
+)
+
+const (
+	Name    = "aws-codebuild"
+	Type    = "https://witness.dev/attestations/aws-codebuild/v0.1"
+	RunType = attestation.PreMaterialRunType
+
+	// Environment variables available in AWS CodeBuild
+	envCodeBuildBuildID            = "CODEBUILD_BUILD_ID"
+	envCodeBuildBuildARN           = "CODEBUILD_BUILD_ARN"
+	envCodeBuildBuildNumber        = "CODEBUILD_BUILD_NUMBER"
+	envCodeBuildInitiator          = "CODEBUILD_INITIATOR"
+	envCodeBuildProjectName        = "CODEBUILD_PROJECT_NAME"
+	envCodeBuildResolvedSrcVer     = "CODEBUILD_RESOLVED_SOURCE_VERSION"
+	envCodeBuildSourceRepo         = "CODEBUILD_SOURCE_REPO_URL"
+	envCodeBuildBatchBuildID       = "CODEBUILD_BATCH_BUILD_IDENTIFIER"
+	envCodeBuildWebhookEvent       = "CODEBUILD_WEBHOOK_EVENT"
+	envCodeBuildWebhookHeadRef     = "CODEBUILD_WEBHOOK_HEAD_REF"
+	envCodeBuildWebhookActorAcctID = "CODEBUILD_WEBHOOK_ACTOR_ACCOUNT_ID"
+	envAWSRegion                   = "AWS_REGION"
+)
+
+// Ensure Attestor implements the required interfaces at compile time
+var (
+	_ attestation.Attestor   = &Attestor{}
+	_ attestation.Subjecter  = &Attestor{}
+	_ attestation.BackReffer = &Attestor{}
+)
+
+func init() {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
+		return New()
+	})
+}
+
+// BuildInfo represents AWS CodeBuild metadata
+type BuildInfo struct {
+	BuildID        string           `json:"build_id"`
+	BuildARN       string           `json:"build_arn,omitempty"`
+	BuildNumber    string           `json:"build_number,omitempty"`
+	ProjectName    string           `json:"project_name,omitempty"`
+	Initiator      string           `json:"initiator,omitempty"`
+	SourceVersion  string           `json:"source_version,omitempty"`
+	SourceRepo     string           `json:"source_repo,omitempty"`
+	BatchBuildID   string           `json:"batch_build_id,omitempty"`
+	WebhookEvent   string           `json:"webhook_event,omitempty"`
+	WebhookHeadRef string           `json:"webhook_head_ref,omitempty"`
+	WebhookActorID string           `json:"webhook_actor_id,omitempty"`
+	Region         string           `json:"region,omitempty"`
+	BuildDetails   *codebuild.Build `json:"build_details,omitempty"`
+}
+
+type Attestor struct {
+	hashes          []cryptoutil.DigestValue
+	session         *session.Session
+	conf            *aws.Config
+	BuildInfo       BuildInfo `json:"build_info"`
+	RawBuildDetails string    `json:"raw_build_details,omitempty"`
+}
+
+func New() *Attestor {
+	sess, err := session.NewSession()
+	if err != nil {
+		return &Attestor{
+			BuildInfo: BuildInfo{},
+		}
+	}
+
+	conf := &aws.Config{}
+	// If AWS_REGION is available, use it explicitly
+	if region := os.Getenv(envAWSRegion); region != "" {
+		conf.Region = aws.String(region)
+	}
+
+	return &Attestor{
+		session:   sess,
+		conf:      conf,
+		BuildInfo: BuildInfo{},
+	}
+}
+
+func (a *Attestor) Name() string {
+	return Name
+}
+
+func (a *Attestor) Type() string {
+	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
+}
+
+func (a *Attestor) Schema() *jsonschema.Schema {
+	return jsonschema.Reflect(a)
+}
+
+func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
+	a.hashes = ctx.Hashes()
+
+	// First check if we are running in CodeBuild
+	buildID := os.Getenv(envCodeBuildBuildID)
+	if buildID == "" {
+		return fmt.Errorf("not running in AWS CodeBuild environment, CODEBUILD_BUILD_ID not found")
+	}
+
+	// Initialize basic metadata from environment variables
+	a.BuildInfo.BuildID = buildID
+	a.BuildInfo.BuildARN = os.Getenv(envCodeBuildBuildARN)
+	a.BuildInfo.BuildNumber = os.Getenv(envCodeBuildBuildNumber)
+	a.BuildInfo.ProjectName = os.Getenv(envCodeBuildProjectName)
+	a.BuildInfo.Initiator = os.Getenv(envCodeBuildInitiator)
+	a.BuildInfo.SourceVersion = os.Getenv(envCodeBuildResolvedSrcVer)
+	a.BuildInfo.SourceRepo = os.Getenv(envCodeBuildSourceRepo)
+	a.BuildInfo.BatchBuildID = os.Getenv(envCodeBuildBatchBuildID)
+	a.BuildInfo.WebhookEvent = os.Getenv(envCodeBuildWebhookEvent)
+	a.BuildInfo.WebhookHeadRef = os.Getenv(envCodeBuildWebhookHeadRef)
+	a.BuildInfo.WebhookActorID = os.Getenv(envCodeBuildWebhookActorAcctID)
+	a.BuildInfo.Region = os.Getenv(envAWSRegion)
+
+	// If we have a session, we'll try to get more details from the CodeBuild API
+	if a.session != nil {
+		err := a.getBuildDetails()
+		if err != nil {
+			log.Warnf("Unable to get CodeBuild build details: %v", err)
+			// Continue with environment-based metadata only
+		}
+	}
+
+	return nil
+}
+
+func (a *Attestor) getBuildDetails() error {
+	// Extract the build ID without the project name prefix
+	// e.g., project-name:build-id -> build-id
+	buildIDParts := strings.Split(a.BuildInfo.BuildID, ":")
+	if len(buildIDParts) != 2 {
+		return fmt.Errorf("invalid CODEBUILD_BUILD_ID format: %s", a.BuildInfo.BuildID)
+	}
+	buildID := buildIDParts[1]
+
+	svc := codebuild.New(a.session, a.conf)
+	input := &codebuild.BatchGetBuildsInput{
+		Ids: []*string{aws.String(buildID)},
+	}
+
+	result, err := svc.BatchGetBuilds(input)
+	if err != nil {
+		return fmt.Errorf("failed to get build details: %w", err)
+	}
+
+	if len(result.Builds) == 0 {
+		return fmt.Errorf("no build found with ID: %s", buildID)
+	}
+
+	build := result.Builds[0]
+	a.BuildInfo.BuildDetails = build
+
+	// Store raw build details for verification
+	rawDetails, err := json.Marshal(build)
+	if err != nil {
+		return fmt.Errorf("failed to marshal build details: %w", err)
+	}
+
+	a.RawBuildDetails = string(rawDetails)
+	return nil
+}
+
+func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
+	hashes := []cryptoutil.DigestValue{{Hash: crypto.SHA256}}
+	subjects := make(map[string]cryptoutil.DigestSet)
+
+	// Add build ID as subject
+	if a.BuildInfo.BuildID != "" {
+		if ds, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.BuildInfo.BuildID), hashes); err == nil {
+			subjects[fmt.Sprintf("codebuild-build-id:%s", a.BuildInfo.BuildID)] = ds
+		} else {
+			log.Debugf("(attestation/aws-codebuild) failed to record build ID subject: %v", err)
+		}
+	}
+
+	// Add project name as subject
+	if a.BuildInfo.ProjectName != "" {
+		if ds, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.BuildInfo.ProjectName), hashes); err == nil {
+			subjects[fmt.Sprintf("codebuild-project:%s", a.BuildInfo.ProjectName)] = ds
+		} else {
+			log.Debugf("(attestation/aws-codebuild) failed to record project name subject: %v", err)
+		}
+	}
+
+	// Add source version (git commit) as subject
+	if a.BuildInfo.SourceVersion != "" {
+		if ds, err := cryptoutil.CalculateDigestSetFromBytes([]byte(a.BuildInfo.SourceVersion), hashes); err == nil {
+			subjects[fmt.Sprintf("codebuild-source-version:%s", a.BuildInfo.SourceVersion)] = ds
+		} else {
+			log.Debugf("(attestation/aws-codebuild) failed to record source version subject: %v", err)
+		}
+	}
+
+	return subjects
+}
+
+func (a *Attestor) BackRefs() map[string]cryptoutil.DigestSet {
+	// Same as Subjects() for now, but we could be more selective in the future
+	return a.Subjects()
+}

--- a/attestation/aws-codebuild/aws-codebuild_test.go
+++ b/attestation/aws-codebuild/aws-codebuild_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws_codebuild
+
+import (
+	"os"
+	"testing"
+
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	attestor := New()
+	assert.NotNil(t, attestor)
+}
+
+func TestAttestorName(t *testing.T) {
+	attestor := New()
+	assert.Equal(t, Name, attestor.Name())
+}
+
+func TestAttestorType(t *testing.T) {
+	attestor := New()
+	assert.Equal(t, Type, attestor.Type())
+}
+
+func TestAttestorRunType(t *testing.T) {
+	attestor := New()
+	assert.Equal(t, RunType, attestor.RunType())
+}
+
+func TestAttestorSchema(t *testing.T) {
+	attestor := New()
+	schema := attestor.Schema()
+	assert.NotNil(t, schema)
+}
+
+func TestAttest(t *testing.T) {
+	// Save original env vars
+	origBuildID := os.Getenv(envCodeBuildBuildID)
+	origBuildARN := os.Getenv(envCodeBuildBuildARN)
+	origBuildNumber := os.Getenv(envCodeBuildBuildNumber)
+	origProjectName := os.Getenv(envCodeBuildProjectName)
+	origInitiator := os.Getenv(envCodeBuildInitiator)
+	origSourceVersion := os.Getenv(envCodeBuildResolvedSrcVer)
+	origSourceRepo := os.Getenv(envCodeBuildSourceRepo)
+
+	// Cleanup env vars after test
+	defer func() {
+		os.Setenv(envCodeBuildBuildID, origBuildID)
+		os.Setenv(envCodeBuildBuildARN, origBuildARN)
+		os.Setenv(envCodeBuildBuildNumber, origBuildNumber)
+		os.Setenv(envCodeBuildProjectName, origProjectName)
+		os.Setenv(envCodeBuildInitiator, origInitiator)
+		os.Setenv(envCodeBuildResolvedSrcVer, origSourceVersion)
+		os.Setenv(envCodeBuildSourceRepo, origSourceRepo)
+	}()
+
+	t.Run("not in CodeBuild environment", func(t *testing.T) {
+		os.Unsetenv(envCodeBuildBuildID)
+
+		attestor := New()
+		ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
+		require.NoError(t, err)
+
+		err = attestor.Attest(ctx)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not running in AWS CodeBuild environment")
+	})
+
+	t.Run("in CodeBuild environment", func(t *testing.T) {
+		// Set mock env vars
+		os.Setenv(envCodeBuildBuildID, "project:build-id-123")
+		os.Setenv(envCodeBuildBuildARN, "arn:aws:codebuild:us-west-2:123456789012:build/project:build-id-123")
+		os.Setenv(envCodeBuildBuildNumber, "1")
+		os.Setenv(envCodeBuildProjectName, "my-project")
+		os.Setenv(envCodeBuildInitiator, "user")
+		os.Setenv(envCodeBuildResolvedSrcVer, "0123456789abcdef0123456789abcdef01234567")
+		os.Setenv(envCodeBuildSourceRepo, "https://github.com/example/repo.git")
+
+		attestor := New()
+		// Disable session to avoid API calls
+		attestor.session = nil
+
+		ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
+		require.NoError(t, err)
+
+		err = attestor.Attest(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, "project:build-id-123", attestor.BuildInfo.BuildID)
+		assert.Equal(t, "arn:aws:codebuild:us-west-2:123456789012:build/project:build-id-123", attestor.BuildInfo.BuildARN)
+		assert.Equal(t, "1", attestor.BuildInfo.BuildNumber)
+		assert.Equal(t, "my-project", attestor.BuildInfo.ProjectName)
+		assert.Equal(t, "user", attestor.BuildInfo.Initiator)
+		assert.Equal(t, "0123456789abcdef0123456789abcdef01234567", attestor.BuildInfo.SourceVersion)
+		assert.Equal(t, "https://github.com/example/repo.git", attestor.BuildInfo.SourceRepo)
+	})
+}
+
+func TestSubjects(t *testing.T) {
+	// Set mock data
+	attestor := New()
+	attestor.BuildInfo.BuildID = "project:build-id-123"
+	attestor.BuildInfo.ProjectName = "my-project"
+	attestor.BuildInfo.SourceVersion = "0123456789abcdef0123456789abcdef01234567"
+
+	subjects := attestor.Subjects()
+
+	assert.Contains(t, subjects, "codebuild-build-id:project:build-id-123")
+	assert.Contains(t, subjects, "codebuild-project:my-project")
+	assert.Contains(t, subjects, "codebuild-source-version:0123456789abcdef0123456789abcdef01234567")
+}
+
+func TestBackRefs(t *testing.T) {
+	// Set mock data
+	attestor := New()
+	attestor.BuildInfo.BuildID = "project:build-id-123"
+	attestor.BuildInfo.ProjectName = "my-project"
+	attestor.BuildInfo.SourceVersion = "0123456789abcdef0123456789abcdef01234567"
+
+	backrefs := attestor.BackRefs()
+
+	assert.Contains(t, backrefs, "codebuild-build-id:project:build-id-123")
+	assert.Contains(t, backrefs, "codebuild-project:my-project")
+	assert.Contains(t, backrefs, "codebuild-source-version:0123456789abcdef0123456789abcdef01234567")
+}

--- a/imports.go
+++ b/imports.go
@@ -17,6 +17,7 @@ package witness
 // all of the following imports are here so that each of the package's init functions run appropriately
 import (
 	// attestors
+	_ "github.com/in-toto/go-witness/attestation/aws-codebuild"
 	_ "github.com/in-toto/go-witness/attestation/aws-iid"
 	_ "github.com/in-toto/go-witness/attestation/commandrun"
 	_ "github.com/in-toto/go-witness/attestation/docker"
@@ -33,6 +34,7 @@ import (
 	_ "github.com/in-toto/go-witness/attestation/material"
 	_ "github.com/in-toto/go-witness/attestation/maven"
 	_ "github.com/in-toto/go-witness/attestation/oci"
+	_ "github.com/in-toto/go-witness/attestation/omnitrail"
 	_ "github.com/in-toto/go-witness/attestation/policyverify"
 	_ "github.com/in-toto/go-witness/attestation/product"
 	_ "github.com/in-toto/go-witness/attestation/sarif"

--- a/schemagen/aws-codebuild.json
+++ b/schemagen/aws-codebuild.json
@@ -1,0 +1,730 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/in-toto/go-witness/attestation/aws-codebuild/attestor",
+  "$ref": "#/$defs/Attestor",
+  "$defs": {
+    "Attestor": {
+      "properties": {
+        "build_info": {
+          "$ref": "#/$defs/BuildInfo"
+        },
+        "raw_build_details": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "build_info"
+      ]
+    },
+    "Build": {
+      "properties": {
+        "Arn": {
+          "type": "string"
+        },
+        "Artifacts": {
+          "$ref": "#/$defs/BuildArtifacts"
+        },
+        "BuildBatchArn": {
+          "type": "string"
+        },
+        "BuildComplete": {
+          "type": "boolean"
+        },
+        "BuildNumber": {
+          "type": "integer"
+        },
+        "BuildStatus": {
+          "type": "string"
+        },
+        "Cache": {
+          "$ref": "#/$defs/ProjectCache"
+        },
+        "CurrentPhase": {
+          "type": "string"
+        },
+        "DebugSession": {
+          "$ref": "#/$defs/DebugSession"
+        },
+        "EncryptionKey": {
+          "type": "string"
+        },
+        "EndTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "Environment": {
+          "$ref": "#/$defs/ProjectEnvironment"
+        },
+        "ExportedEnvironmentVariables": {
+          "items": {
+            "$ref": "#/$defs/ExportedEnvironmentVariable"
+          },
+          "type": "array"
+        },
+        "FileSystemLocations": {
+          "items": {
+            "$ref": "#/$defs/ProjectFileSystemLocation"
+          },
+          "type": "array"
+        },
+        "Id": {
+          "type": "string"
+        },
+        "Initiator": {
+          "type": "string"
+        },
+        "Logs": {
+          "$ref": "#/$defs/LogsLocation"
+        },
+        "NetworkInterface": {
+          "$ref": "#/$defs/NetworkInterface"
+        },
+        "Phases": {
+          "items": {
+            "$ref": "#/$defs/BuildPhase"
+          },
+          "type": "array"
+        },
+        "ProjectName": {
+          "type": "string"
+        },
+        "QueuedTimeoutInMinutes": {
+          "type": "integer"
+        },
+        "ReportArns": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ResolvedSourceVersion": {
+          "type": "string"
+        },
+        "SecondaryArtifacts": {
+          "items": {
+            "$ref": "#/$defs/BuildArtifacts"
+          },
+          "type": "array"
+        },
+        "SecondarySourceVersions": {
+          "items": {
+            "$ref": "#/$defs/ProjectSourceVersion"
+          },
+          "type": "array"
+        },
+        "SecondarySources": {
+          "items": {
+            "$ref": "#/$defs/ProjectSource"
+          },
+          "type": "array"
+        },
+        "ServiceRole": {
+          "type": "string"
+        },
+        "Source": {
+          "$ref": "#/$defs/ProjectSource"
+        },
+        "SourceVersion": {
+          "type": "string"
+        },
+        "StartTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "TimeoutInMinutes": {
+          "type": "integer"
+        },
+        "VpcConfig": {
+          "$ref": "#/$defs/VpcConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Arn",
+        "Artifacts",
+        "BuildBatchArn",
+        "BuildComplete",
+        "BuildNumber",
+        "BuildStatus",
+        "Cache",
+        "CurrentPhase",
+        "DebugSession",
+        "EncryptionKey",
+        "EndTime",
+        "Environment",
+        "ExportedEnvironmentVariables",
+        "FileSystemLocations",
+        "Id",
+        "Initiator",
+        "Logs",
+        "NetworkInterface",
+        "Phases",
+        "ProjectName",
+        "QueuedTimeoutInMinutes",
+        "ReportArns",
+        "ResolvedSourceVersion",
+        "SecondaryArtifacts",
+        "SecondarySourceVersions",
+        "SecondarySources",
+        "ServiceRole",
+        "Source",
+        "SourceVersion",
+        "StartTime",
+        "TimeoutInMinutes",
+        "VpcConfig"
+      ]
+    },
+    "BuildArtifacts": {
+      "properties": {
+        "ArtifactIdentifier": {
+          "type": "string"
+        },
+        "BucketOwnerAccess": {
+          "type": "string"
+        },
+        "EncryptionDisabled": {
+          "type": "boolean"
+        },
+        "Location": {
+          "type": "string"
+        },
+        "Md5sum": {
+          "type": "string"
+        },
+        "OverrideArtifactName": {
+          "type": "boolean"
+        },
+        "Sha256sum": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ArtifactIdentifier",
+        "BucketOwnerAccess",
+        "EncryptionDisabled",
+        "Location",
+        "Md5sum",
+        "OverrideArtifactName",
+        "Sha256sum"
+      ]
+    },
+    "BuildInfo": {
+      "properties": {
+        "build_id": {
+          "type": "string"
+        },
+        "build_arn": {
+          "type": "string"
+        },
+        "build_number": {
+          "type": "string"
+        },
+        "project_name": {
+          "type": "string"
+        },
+        "initiator": {
+          "type": "string"
+        },
+        "source_version": {
+          "type": "string"
+        },
+        "source_repo": {
+          "type": "string"
+        },
+        "batch_build_id": {
+          "type": "string"
+        },
+        "webhook_event": {
+          "type": "string"
+        },
+        "webhook_head_ref": {
+          "type": "string"
+        },
+        "webhook_actor_id": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        },
+        "build_details": {
+          "$ref": "#/$defs/Build"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "build_id"
+      ]
+    },
+    "BuildPhase": {
+      "properties": {
+        "Contexts": {
+          "items": {
+            "$ref": "#/$defs/PhaseContext"
+          },
+          "type": "array"
+        },
+        "DurationInSeconds": {
+          "type": "integer"
+        },
+        "EndTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "PhaseStatus": {
+          "type": "string"
+        },
+        "PhaseType": {
+          "type": "string"
+        },
+        "StartTime": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Contexts",
+        "DurationInSeconds",
+        "EndTime",
+        "PhaseStatus",
+        "PhaseType",
+        "StartTime"
+      ]
+    },
+    "BuildStatusConfig": {
+      "properties": {
+        "Context": {
+          "type": "string"
+        },
+        "TargetUrl": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Context",
+        "TargetUrl"
+      ]
+    },
+    "CloudWatchLogsConfig": {
+      "properties": {
+        "GroupName": {
+          "type": "string"
+        },
+        "Status": {
+          "type": "string"
+        },
+        "StreamName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "GroupName",
+        "Status",
+        "StreamName"
+      ]
+    },
+    "DebugSession": {
+      "properties": {
+        "SessionEnabled": {
+          "type": "boolean"
+        },
+        "SessionTarget": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "SessionEnabled",
+        "SessionTarget"
+      ]
+    },
+    "EnvironmentVariable": {
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Name",
+        "Type",
+        "Value"
+      ]
+    },
+    "ExportedEnvironmentVariable": {
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "Value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Name",
+        "Value"
+      ]
+    },
+    "GitSubmodulesConfig": {
+      "properties": {
+        "FetchSubmodules": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "FetchSubmodules"
+      ]
+    },
+    "LogsLocation": {
+      "properties": {
+        "CloudWatchLogs": {
+          "$ref": "#/$defs/CloudWatchLogsConfig"
+        },
+        "CloudWatchLogsArn": {
+          "type": "string"
+        },
+        "DeepLink": {
+          "type": "string"
+        },
+        "GroupName": {
+          "type": "string"
+        },
+        "S3DeepLink": {
+          "type": "string"
+        },
+        "S3Logs": {
+          "$ref": "#/$defs/S3LogsConfig"
+        },
+        "S3LogsArn": {
+          "type": "string"
+        },
+        "StreamName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "CloudWatchLogs",
+        "CloudWatchLogsArn",
+        "DeepLink",
+        "GroupName",
+        "S3DeepLink",
+        "S3Logs",
+        "S3LogsArn",
+        "StreamName"
+      ]
+    },
+    "NetworkInterface": {
+      "properties": {
+        "NetworkInterfaceId": {
+          "type": "string"
+        },
+        "SubnetId": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "NetworkInterfaceId",
+        "SubnetId"
+      ]
+    },
+    "PhaseContext": {
+      "properties": {
+        "Message": {
+          "type": "string"
+        },
+        "StatusCode": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Message",
+        "StatusCode"
+      ]
+    },
+    "ProjectCache": {
+      "properties": {
+        "Location": {
+          "type": "string"
+        },
+        "Modes": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Location",
+        "Modes",
+        "Type"
+      ]
+    },
+    "ProjectEnvironment": {
+      "properties": {
+        "Certificate": {
+          "type": "string"
+        },
+        "ComputeType": {
+          "type": "string"
+        },
+        "EnvironmentVariables": {
+          "items": {
+            "$ref": "#/$defs/EnvironmentVariable"
+          },
+          "type": "array"
+        },
+        "Fleet": {
+          "$ref": "#/$defs/ProjectFleet"
+        },
+        "Image": {
+          "type": "string"
+        },
+        "ImagePullCredentialsType": {
+          "type": "string"
+        },
+        "PrivilegedMode": {
+          "type": "boolean"
+        },
+        "RegistryCredential": {
+          "$ref": "#/$defs/RegistryCredential"
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Certificate",
+        "ComputeType",
+        "EnvironmentVariables",
+        "Fleet",
+        "Image",
+        "ImagePullCredentialsType",
+        "PrivilegedMode",
+        "RegistryCredential",
+        "Type"
+      ]
+    },
+    "ProjectFileSystemLocation": {
+      "properties": {
+        "Identifier": {
+          "type": "string"
+        },
+        "Location": {
+          "type": "string"
+        },
+        "MountOptions": {
+          "type": "string"
+        },
+        "MountPoint": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Identifier",
+        "Location",
+        "MountOptions",
+        "MountPoint",
+        "Type"
+      ]
+    },
+    "ProjectFleet": {
+      "properties": {
+        "FleetArn": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "FleetArn"
+      ]
+    },
+    "ProjectSource": {
+      "properties": {
+        "Auth": {
+          "$ref": "#/$defs/SourceAuth"
+        },
+        "BuildStatusConfig": {
+          "$ref": "#/$defs/BuildStatusConfig"
+        },
+        "Buildspec": {
+          "type": "string"
+        },
+        "GitCloneDepth": {
+          "type": "integer"
+        },
+        "GitSubmodulesConfig": {
+          "$ref": "#/$defs/GitSubmodulesConfig"
+        },
+        "InsecureSsl": {
+          "type": "boolean"
+        },
+        "Location": {
+          "type": "string"
+        },
+        "ReportBuildStatus": {
+          "type": "boolean"
+        },
+        "SourceIdentifier": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Auth",
+        "BuildStatusConfig",
+        "Buildspec",
+        "GitCloneDepth",
+        "GitSubmodulesConfig",
+        "InsecureSsl",
+        "Location",
+        "ReportBuildStatus",
+        "SourceIdentifier",
+        "Type"
+      ]
+    },
+    "ProjectSourceVersion": {
+      "properties": {
+        "SourceIdentifier": {
+          "type": "string"
+        },
+        "SourceVersion": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "SourceIdentifier",
+        "SourceVersion"
+      ]
+    },
+    "RegistryCredential": {
+      "properties": {
+        "Credential": {
+          "type": "string"
+        },
+        "CredentialProvider": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Credential",
+        "CredentialProvider"
+      ]
+    },
+    "S3LogsConfig": {
+      "properties": {
+        "BucketOwnerAccess": {
+          "type": "string"
+        },
+        "EncryptionDisabled": {
+          "type": "boolean"
+        },
+        "Location": {
+          "type": "string"
+        },
+        "Status": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "BucketOwnerAccess",
+        "EncryptionDisabled",
+        "Location",
+        "Status"
+      ]
+    },
+    "SourceAuth": {
+      "properties": {
+        "Resource": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Resource",
+        "Type"
+      ]
+    },
+    "VpcConfig": {
+      "properties": {
+        "SecurityGroupIds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "Subnets": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "VpcId": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "SecurityGroupIds",
+        "Subnets",
+        "VpcId"
+      ]
+    }
+  }
+}

--- a/schemagen/gcp-iit.json
+++ b/schemagen/gcp-iit.json
@@ -249,6 +249,30 @@
                     "$ref": "#/$defs/OID"
                   },
                   "type": "array"
+                },
+                "InhibitAnyPolicy": {
+                  "type": "integer"
+                },
+                "InhibitAnyPolicyZero": {
+                  "type": "boolean"
+                },
+                "InhibitPolicyMapping": {
+                  "type": "integer"
+                },
+                "InhibitPolicyMappingZero": {
+                  "type": "boolean"
+                },
+                "RequireExplicitPolicy": {
+                  "type": "integer"
+                },
+                "RequireExplicitPolicyZero": {
+                  "type": "boolean"
+                },
+                "PolicyMappings": {
+                  "items": {
+                    "$ref": "#/$defs/PolicyMapping"
+                  },
+                  "type": "array"
                 }
               },
               "additionalProperties": false,
@@ -298,7 +322,14 @@
                 "ExcludedURIDomains",
                 "CRLDistributionPoints",
                 "PolicyIdentifiers",
-                "Policies"
+                "Policies",
+                "InhibitAnyPolicy",
+                "InhibitAnyPolicyZero",
+                "InhibitPolicyMapping",
+                "InhibitPolicyMappingZero",
+                "RequireExplicitPolicy",
+                "RequireExplicitPolicyZero",
+                "PolicyMappings"
               ]
             },
             "Extension": {
@@ -481,6 +512,22 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "PolicyMapping": {
+              "properties": {
+                "IssuerDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                },
+                "SubjectDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "IssuerDomainPolicy",
+                "SubjectDomainPolicy"
+              ]
             },
             "VerificationInfo": {
               "properties": {

--- a/schemagen/github.json
+++ b/schemagen/github.json
@@ -249,6 +249,30 @@
                     "$ref": "#/$defs/OID"
                   },
                   "type": "array"
+                },
+                "InhibitAnyPolicy": {
+                  "type": "integer"
+                },
+                "InhibitAnyPolicyZero": {
+                  "type": "boolean"
+                },
+                "InhibitPolicyMapping": {
+                  "type": "integer"
+                },
+                "InhibitPolicyMappingZero": {
+                  "type": "boolean"
+                },
+                "RequireExplicitPolicy": {
+                  "type": "integer"
+                },
+                "RequireExplicitPolicyZero": {
+                  "type": "boolean"
+                },
+                "PolicyMappings": {
+                  "items": {
+                    "$ref": "#/$defs/PolicyMapping"
+                  },
+                  "type": "array"
                 }
               },
               "additionalProperties": false,
@@ -298,7 +322,14 @@
                 "ExcludedURIDomains",
                 "CRLDistributionPoints",
                 "PolicyIdentifiers",
-                "Policies"
+                "Policies",
+                "InhibitAnyPolicy",
+                "InhibitAnyPolicyZero",
+                "InhibitPolicyMapping",
+                "InhibitPolicyMappingZero",
+                "RequireExplicitPolicy",
+                "RequireExplicitPolicyZero",
+                "PolicyMappings"
               ]
             },
             "Extension": {
@@ -481,6 +512,22 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "PolicyMapping": {
+              "properties": {
+                "IssuerDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                },
+                "SubjectDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "IssuerDomainPolicy",
+                "SubjectDomainPolicy"
+              ]
             },
             "VerificationInfo": {
               "properties": {

--- a/schemagen/gitlab.json
+++ b/schemagen/gitlab.json
@@ -249,6 +249,30 @@
                     "$ref": "#/$defs/OID"
                   },
                   "type": "array"
+                },
+                "InhibitAnyPolicy": {
+                  "type": "integer"
+                },
+                "InhibitAnyPolicyZero": {
+                  "type": "boolean"
+                },
+                "InhibitPolicyMapping": {
+                  "type": "integer"
+                },
+                "InhibitPolicyMappingZero": {
+                  "type": "boolean"
+                },
+                "RequireExplicitPolicy": {
+                  "type": "integer"
+                },
+                "RequireExplicitPolicyZero": {
+                  "type": "boolean"
+                },
+                "PolicyMappings": {
+                  "items": {
+                    "$ref": "#/$defs/PolicyMapping"
+                  },
+                  "type": "array"
                 }
               },
               "additionalProperties": false,
@@ -298,7 +322,14 @@
                 "ExcludedURIDomains",
                 "CRLDistributionPoints",
                 "PolicyIdentifiers",
-                "Policies"
+                "Policies",
+                "InhibitAnyPolicy",
+                "InhibitAnyPolicyZero",
+                "InhibitPolicyMapping",
+                "InhibitPolicyMappingZero",
+                "RequireExplicitPolicy",
+                "RequireExplicitPolicyZero",
+                "PolicyMappings"
               ]
             },
             "Extension": {
@@ -481,6 +512,22 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "PolicyMapping": {
+              "properties": {
+                "IssuerDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                },
+                "SubjectDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "IssuerDomainPolicy",
+                "SubjectDomainPolicy"
+              ]
             },
             "VerificationInfo": {
               "properties": {

--- a/schemagen/jwt.json
+++ b/schemagen/jwt.json
@@ -243,6 +243,30 @@
             "$ref": "#/$defs/OID"
           },
           "type": "array"
+        },
+        "InhibitAnyPolicy": {
+          "type": "integer"
+        },
+        "InhibitAnyPolicyZero": {
+          "type": "boolean"
+        },
+        "InhibitPolicyMapping": {
+          "type": "integer"
+        },
+        "InhibitPolicyMappingZero": {
+          "type": "boolean"
+        },
+        "RequireExplicitPolicy": {
+          "type": "integer"
+        },
+        "RequireExplicitPolicyZero": {
+          "type": "boolean"
+        },
+        "PolicyMappings": {
+          "items": {
+            "$ref": "#/$defs/PolicyMapping"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -292,7 +316,14 @@
         "ExcludedURIDomains",
         "CRLDistributionPoints",
         "PolicyIdentifiers",
-        "Policies"
+        "Policies",
+        "InhibitAnyPolicy",
+        "InhibitAnyPolicyZero",
+        "InhibitPolicyMapping",
+        "InhibitPolicyMappingZero",
+        "RequireExplicitPolicy",
+        "RequireExplicitPolicyZero",
+        "PolicyMappings"
       ]
     },
     "Extension": {
@@ -475,6 +506,22 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    "PolicyMapping": {
+      "properties": {
+        "IssuerDomainPolicy": {
+          "$ref": "#/$defs/OID"
+        },
+        "SubjectDomainPolicy": {
+          "$ref": "#/$defs/OID"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "IssuerDomainPolicy",
+        "SubjectDomainPolicy"
+      ]
     },
     "VerificationInfo": {
       "properties": {


### PR DESCRIPTION
# AWS CodeBuild Attestor PR

## What this PR does / why we need it

This PR adds a new attestor for AWS CodeBuild CI/CD environments. The AWS CodeBuild attestor captures metadata and provenance information when witness is used within AWS CodeBuild pipelines, enabling enhanced supply chain security for builds running on AWS CodeBuild.

Key features:
- Collects build information from AWS CodeBuild environment variables
- Retrieves additional build details from the AWS CodeBuild API when AWS credentials are available
- Creates subjects based on build ID, project name, and source version for policy verification
- Includes comprehensive schema definition for AWS CodeBuild metadata
- Provides documentation for usage and implementation

This attestor enhances witness's CI/CD coverage by adding support for the AWS CodeBuild platform, complementing existing attestors for other CI/CD environments such as GitHub and GitLab.

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

The implementation follows the pattern of other CI/CD attestors, capturing environment-specific metadata and providing subject identifiers for policy verification. The attestor gracefully handles cases where AWS API access is unavailable, falling back to environment variable-based attestation.

Let me know if this meets expectations or if there are any concerns about the approach. 
TestifySec has a few codebuild stages in our codepipeline we could test this with some time.