### PR TITLE
Update schema definitions with PolicyMapping

### DIFF
--- a/schemagen/gcp-iit.json
+++ b/schemagen/gcp-iit.json
@@ -249,6 +249,30 @@
                     "$ref": "#/$defs/OID"
                   },
                   "type": "array"
+                },
+                "InhibitAnyPolicy": {
+                  "type": "integer"
+                },
+                "InhibitAnyPolicyZero": {
+                  "type": "boolean"
+                },
+                "InhibitPolicyMapping": {
+                  "type": "integer"
+                },
+                "InhibitPolicyMappingZero": {
+                  "type": "boolean"
+                },
+                "RequireExplicitPolicy": {
+                  "type": "integer"
+                },
+                "RequireExplicitPolicyZero": {
+                  "type": "boolean"
+                },
+                "PolicyMappings": {
+                  "items": {
+                    "$ref": "#/$defs/PolicyMapping"
+                  },
+                  "type": "array"
                 }
               },
               "additionalProperties": false,
@@ -298,7 +322,14 @@
                 "ExcludedURIDomains",
                 "CRLDistributionPoints",
                 "PolicyIdentifiers",
-                "Policies"
+                "Policies",
+                "InhibitAnyPolicy",
+                "InhibitAnyPolicyZero",
+                "InhibitPolicyMapping",
+                "InhibitPolicyMappingZero",
+                "RequireExplicitPolicy",
+                "RequireExplicitPolicyZero",
+                "PolicyMappings"
               ]
             },
             "Extension": {
@@ -481,6 +512,22 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "PolicyMapping": {
+              "properties": {
+                "IssuerDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                },
+                "SubjectDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "IssuerDomainPolicy",
+                "SubjectDomainPolicy"
+              ]
             },
             "VerificationInfo": {
               "properties": {

--- a/schemagen/github.json
+++ b/schemagen/github.json
@@ -249,6 +249,30 @@
                     "$ref": "#/$defs/OID"
                   },
                   "type": "array"
+                },
+                "InhibitAnyPolicy": {
+                  "type": "integer"
+                },
+                "InhibitAnyPolicyZero": {
+                  "type": "boolean"
+                },
+                "InhibitPolicyMapping": {
+                  "type": "integer"
+                },
+                "InhibitPolicyMappingZero": {
+                  "type": "boolean"
+                },
+                "RequireExplicitPolicy": {
+                  "type": "integer"
+                },
+                "RequireExplicitPolicyZero": {
+                  "type": "boolean"
+                },
+                "PolicyMappings": {
+                  "items": {
+                    "$ref": "#/$defs/PolicyMapping"
+                  },
+                  "type": "array"
                 }
               },
               "additionalProperties": false,
@@ -298,7 +322,14 @@
                 "ExcludedURIDomains",
                 "CRLDistributionPoints",
                 "PolicyIdentifiers",
-                "Policies"
+                "Policies",
+                "InhibitAnyPolicy",
+                "InhibitAnyPolicyZero",
+                "InhibitPolicyMapping",
+                "InhibitPolicyMappingZero",
+                "RequireExplicitPolicy",
+                "RequireExplicitPolicyZero",
+                "PolicyMappings"
               ]
             },
             "Extension": {
@@ -481,6 +512,22 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "PolicyMapping": {
+              "properties": {
+                "IssuerDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                },
+                "SubjectDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "IssuerDomainPolicy",
+                "SubjectDomainPolicy"
+              ]
             },
             "VerificationInfo": {
               "properties": {

--- a/schemagen/gitlab.json
+++ b/schemagen/gitlab.json
@@ -249,6 +249,30 @@
                     "$ref": "#/$defs/OID"
                   },
                   "type": "array"
+                },
+                "InhibitAnyPolicy": {
+                  "type": "integer"
+                },
+                "InhibitAnyPolicyZero": {
+                  "type": "boolean"
+                },
+                "InhibitPolicyMapping": {
+                  "type": "integer"
+                },
+                "InhibitPolicyMappingZero": {
+                  "type": "boolean"
+                },
+                "RequireExplicitPolicy": {
+                  "type": "integer"
+                },
+                "RequireExplicitPolicyZero": {
+                  "type": "boolean"
+                },
+                "PolicyMappings": {
+                  "items": {
+                    "$ref": "#/$defs/PolicyMapping"
+                  },
+                  "type": "array"
                 }
               },
               "additionalProperties": false,
@@ -298,7 +322,14 @@
                 "ExcludedURIDomains",
                 "CRLDistributionPoints",
                 "PolicyIdentifiers",
-                "Policies"
+                "Policies",
+                "InhibitAnyPolicy",
+                "InhibitAnyPolicyZero",
+                "InhibitPolicyMapping",
+                "InhibitPolicyMappingZero",
+                "RequireExplicitPolicy",
+                "RequireExplicitPolicyZero",
+                "PolicyMappings"
               ]
             },
             "Extension": {
@@ -481,6 +512,22 @@
                 "type": "integer"
               },
               "type": "array"
+            },
+            "PolicyMapping": {
+              "properties": {
+                "IssuerDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                },
+                "SubjectDomainPolicy": {
+                  "$ref": "#/$defs/OID"
+                }
+              },
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "IssuerDomainPolicy",
+                "SubjectDomainPolicy"
+              ]
             },
             "VerificationInfo": {
               "properties": {

--- a/schemagen/jwt.json
+++ b/schemagen/jwt.json
@@ -243,6 +243,30 @@
             "$ref": "#/$defs/OID"
           },
           "type": "array"
+        },
+        "InhibitAnyPolicy": {
+          "type": "integer"
+        },
+        "InhibitAnyPolicyZero": {
+          "type": "boolean"
+        },
+        "InhibitPolicyMapping": {
+          "type": "integer"
+        },
+        "InhibitPolicyMappingZero": {
+          "type": "boolean"
+        },
+        "RequireExplicitPolicy": {
+          "type": "integer"
+        },
+        "RequireExplicitPolicyZero": {
+          "type": "boolean"
+        },
+        "PolicyMappings": {
+          "items": {
+            "$ref": "#/$defs/PolicyMapping"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
@@ -292,7 +316,14 @@
         "ExcludedURIDomains",
         "CRLDistributionPoints",
         "PolicyIdentifiers",
-        "Policies"
+        "Policies",
+        "InhibitAnyPolicy",
+        "InhibitAnyPolicyZero",
+        "InhibitPolicyMapping",
+        "InhibitPolicyMappingZero",
+        "RequireExplicitPolicy",
+        "RequireExplicitPolicyZero",
+        "PolicyMappings"
       ]
     },
     "Extension": {
@@ -475,6 +506,22 @@
         "type": "integer"
       },
       "type": "array"
+    },
+    "PolicyMapping": {
+      "properties": {
+        "IssuerDomainPolicy": {
+          "$ref": "#/$defs/OID"
+        },
+        "SubjectDomainPolicy": {
+          "$ref": "#/$defs/OID"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "IssuerDomainPolicy",
+        "SubjectDomainPolicy"
+      ]
     },
     "VerificationInfo": {
       "properties": {


### PR DESCRIPTION
This PR adds PolicyMapping definitions to the schema files to fix schema validation issues. These definitions are required for the secretscan attestor implementation in PR #463.