### PR TITLE
fix: use sha384 for signing proof of possession challenge from fulcio

### DIFF
--- a/signer/fulcio/fulcio.go
+++ b/signer/fulcio/fulcio.go
@@ -369,7 +369,7 @@ func getCert(ctx context.Context, key *ecdsa.PrivateKey, fc fulciopb.CAClient, t
 		return nil, err
 	}
 
-	proof, err := signer.SignMessage(msg, sigo.WithCryptoSignerOpts(crypto.SHA256))
+	proof, err := signer.SignMessage(msg, sigo.WithCryptoSignerOpts(crypto.SHA384))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What this PR does / why we need it

By default we generate an elliptic P384 for our fulcio signer. When we get the proof of possession challenge from fulcio, we were hashing it with SHA256 during the signing process. This was working fine until recently, when we started getting failures while getting certificates from Fulcio.

This seems to trace back to this commit:
https://github.com/sigstore/sigstore/commit/63abeebb6c891fb583a556210cb6d593a95e688b

This adds a registry to map the type of public key and which algorithms to use by default. This expects SHA384 to be used in our case.

Swapping the signer to use SHA384 when signing the challenge fixes our error.

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
