### PR TITLE
feat(schemagen): only update schema files when content changes

### DIFF
--- a/schemagen/schema.go
+++ b/schemagen/schema.go
@@ -51,8 +51,18 @@ func main() {
 			os.Exit(1)
 		}
 
-		log.Printf("Writing schema for attestor %s to %s/%s.json", att.Name(), directory, att.Name())
-		err = os.WriteFile(fmt.Sprintf("%s/%s.json", directory, att.Name()), indented.Bytes(), 0644)
+		fileName := fmt.Sprintf("%s/%s.json", directory, att.Name())
+		newContent := indented.Bytes()
+
+		// Check if file exists and compare content
+		existingContent, err := os.ReadFile(fileName)
+		if err == nil && bytes.Equal(existingContent, newContent) {
+			log.Printf("Schema for attestor %s is up to date, skipping", att.Name())
+			continue
+		}
+
+		log.Printf("Writing schema for attestor %s to %s", att.Name(), fileName)
+		err = os.WriteFile(fileName, newContent, 0644)
 		if err != nil {
 			log.Fatal("Error writing to file:", err)
 		}


### PR DESCRIPTION
## Summary

This PR updates the schema generation tool to only write schema files when their content has actually changed.

## Changes

- Added content comparison before writing schema files
- Skip writing if the new content matches existing file content
- Log when schemas are up to date vs when they need updating

## Benefits

- Reduces unnecessary file updates
- Prevents git noise from unchanged schemas
- Avoids updating file timestamps when content hasn't changed
- Makes it easier to see actual schema changes in version control

## Testing

Run `go run ./schemagen` multiple times and observe that unchanged schemas are skipped:
```
2025/05/23 15:43:48 Schema for attestor environment is up to date, skipping
2025/05/23 15:43:48 Schema for attestor material is up to date, skipping
2025/05/23 15:43:48 Writing schema for attestor product-archive to schemagen/product-archive.json
```