### PR TITLE
feat: add product-archive attestor for individual file attestations

### DIFF
--- a/attestation/factory.go
+++ b/attestation/factory.go
@@ -64,6 +64,22 @@ type Exporter interface {
 	Subjects() map[string]cryptoutil.DigestSet
 }
 
+// MultiExporter allows attestors to export multiple attestations, one for each item.
+// This is useful for attestors that want to create individual attestations for each
+// file or artifact they process.
+type MultiExporter interface {
+	Export() bool
+	ExportedAttestations() []ExportedAttestation
+}
+
+// ExportedAttestation represents a single attestation to be exported
+type ExportedAttestation struct {
+	Predicate     interface{}
+	PredicateType string
+	Subjects      map[string]cryptoutil.DigestSet
+	Name          string // Optional name for this specific attestation
+}
+
 // BackReffer allows attestors to indicate which of their subjects are good candidates
 // to find related attestations.  For example the git attestor's commit hash subject
 // is a good candidate to find all attestation collections that also refer to a specific

--- a/attestation/productarchive/example_test.go
+++ b/attestation/productarchive/example_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package productarchive_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/attestation/productarchive"
+)
+
+// Example demonstrates how the product-archive attestor creates
+// individual attestations for each product file.
+func Example() {
+	// Create a product archive attestor
+	pa := productarchive.New()
+
+	// Simulate having collected some products
+	// (In real usage, these would come from the product attestor)
+	_ = pa.Attest(&attestation.AttestationContext{})
+
+	// The attestor implements MultiExporter, which means it will
+	// create individual attestations for each archived product
+	attestations := pa.ExportedAttestations()
+
+	fmt.Printf("Number of attestations: %d\n", len(attestations))
+
+	// Each attestation contains a single product with its metadata
+	for i, att := range attestations {
+		fmt.Printf("\nAttestation %d:\n", i+1)
+		fmt.Printf("  Name: %s\n", att.Name)
+		fmt.Printf("  Type: %s\n", att.PredicateType)
+		fmt.Printf("  Subjects: %d\n", len(att.Subjects))
+
+		// The predicate contains the archived product data
+		data, _ := json.MarshalIndent(att.Predicate, "  ", "  ")
+		fmt.Printf("  Predicate: %s\n", string(data))
+	}
+
+	// Output:
+	// Number of attestations: 0
+}
+
+// Example_withProducts demonstrates creating attestations for actual products
+func Example_withProducts() {
+	// This example shows how the witness run command would use the attestor
+	// to create individual attestations for each product file.
+
+	// When witness runs with product-archive attestor:
+	// 1. Product attestor collects output files
+	// 2. Product-archive attestor filters and archives products
+	// 3. Instead of one attestation, it creates N attestations (one per file)
+	// 4. Each attestation is signed separately
+	// 5. Result: product-archive/file1.bin, product-archive/file2.txt, etc.
+
+	fmt.Println("Product archive creates individual attestations per file")
+	// Output: Product archive creates individual attestations per file
+}

--- a/attestation/productarchive/metadata_darwin.go
+++ b/attestation/productarchive/metadata_darwin.go
@@ -1,0 +1,81 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package productarchive
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// setFileTimes sets the platform-specific file times
+func setFileTimes(metadata *FileMetadata, stat *syscall.Stat_t) {
+	metadata.AccessTime = stat.Atimespec.Sec
+	metadata.ChangeTime = stat.Ctimespec.Sec
+}
+
+// getBirthTime returns the file creation time on macOS
+func getBirthTime(stat *syscall.Stat_t) *int64 {
+	birthTime := stat.Birthtimespec.Sec
+	return &birthTime
+}
+
+// getXattrs retrieves extended attributes for a file on macOS
+func getXattrs(path string) (map[string]string, error) {
+	// Get list of attribute names
+	size, err := unix.Listxattr(path, nil)
+	if err != nil || size == 0 {
+		return nil, err
+	}
+
+	buf := make([]byte, size)
+	_, err = unix.Listxattr(path, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	xattrs := make(map[string]string)
+	for len(buf) > 0 {
+		// Find null terminator
+		i := 0
+		for i < len(buf) && buf[i] != 0 {
+			i++
+		}
+		if i == 0 {
+			break
+		}
+
+		name := string(buf[:i])
+
+		// Get attribute value
+		valueSize, err := unix.Getxattr(path, name, nil)
+		if err != nil || valueSize == 0 {
+			buf = buf[i+1:]
+			continue
+		}
+
+		value := make([]byte, valueSize)
+		_, err = unix.Getxattr(path, name, value)
+		if err == nil {
+			xattrs[name] = string(value)
+		}
+
+		buf = buf[i+1:]
+	}
+
+	return xattrs, nil
+}

--- a/attestation/productarchive/metadata_linux.go
+++ b/attestation/productarchive/metadata_linux.go
@@ -1,0 +1,82 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package productarchive
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// setFileTimes sets the platform-specific file times
+func setFileTimes(metadata *FileMetadata, stat *syscall.Stat_t) {
+	metadata.AccessTime = stat.Atim.Sec
+	metadata.ChangeTime = stat.Ctim.Sec
+}
+
+// getBirthTime returns nil on Linux as birth time is not consistently available
+func getBirthTime(stat *syscall.Stat_t) *int64 {
+	// Birth time (btime) is available in statx on newer Linux kernels,
+	// but not in the standard stat structure
+	return nil
+}
+
+// getXattrs retrieves extended attributes for a file on Linux
+func getXattrs(path string) (map[string]string, error) {
+	// Get list of attribute names
+	size, err := unix.Listxattr(path, nil)
+	if err != nil || size == 0 {
+		return nil, err
+	}
+
+	buf := make([]byte, size)
+	_, err = unix.Listxattr(path, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	xattrs := make(map[string]string)
+	for len(buf) > 0 {
+		// Find null terminator
+		i := 0
+		for i < len(buf) && buf[i] != 0 {
+			i++
+		}
+		if i == 0 {
+			break
+		}
+
+		name := string(buf[:i])
+
+		// Get attribute value
+		valueSize, err := unix.Getxattr(path, name, nil)
+		if err != nil || valueSize == 0 {
+			buf = buf[i+1:]
+			continue
+		}
+
+		value := make([]byte, valueSize)
+		_, err = unix.Getxattr(path, name, value)
+		if err == nil {
+			xattrs[name] = string(value)
+		}
+
+		buf = buf[i+1:]
+	}
+
+	return xattrs, nil
+}

--- a/attestation/productarchive/metadata_other.go
+++ b/attestation/productarchive/metadata_other.go
@@ -1,0 +1,35 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin && !linux
+
+package productarchive
+
+import "syscall"
+
+// setFileTimes sets the platform-specific file times
+func setFileTimes(metadata *FileMetadata, stat *syscall.Stat_t) {
+	// On Windows and other platforms, time fields may not be available
+	// or have different names. This is a no-op fallback.
+}
+
+// getBirthTime returns nil on platforms that don't support it
+func getBirthTime(stat *syscall.Stat_t) *int64 {
+	return nil
+}
+
+// getXattrs returns nil on platforms that don't support extended attributes
+func getXattrs(path string) (map[string]string, error) {
+	return nil, nil
+}

--- a/attestation/productarchive/productarchive.go
+++ b/attestation/productarchive/productarchive.go
@@ -1,0 +1,481 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package productarchive implements a post-product attestor that creates
+// individual attestations for each output file/product. Unlike other attestors
+// that create a single attestation, this attestor implements MultiExporter
+// to create one attestation per archived product.
+//
+// Each attestation contains:
+// - File metadata (permissions, timestamps, ownership, etc.)
+// - File content (for files within size limit)
+// - Cryptographic digests
+//
+// This allows for fine-grained attestations that can be individually
+// verified and distributed without creating a single large attestation.
+package productarchive
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/gobwas/glob"
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/log"
+	"github.com/in-toto/go-witness/registry"
+	"github.com/invopop/jsonschema"
+)
+
+const (
+	Name    = "product-archive"
+	Type    = "https://witness.dev/attestations/product-archive/v0.1"
+	RunType = attestation.PostProductRunType
+
+	defaultMaxFileSize = int64(100 * 1024 * 1024) // 100MB
+)
+
+// This is a hacky way to create a compile time error in case the attestor
+// doesn't implement the expected interfaces.
+var (
+	_ attestation.Attestor      = &ProductArchive{}
+	_ attestation.MultiExporter = &ProductArchive{}
+)
+
+func init() {
+	attestation.RegisterAttestation(Name, Type, RunType,
+		func() attestation.Attestor { return New() },
+		registry.StringSliceConfigOption(
+			"include-mime-types",
+			"MIME types to include in the archive",
+			[]string{},
+			func(a attestation.Attestor, mimeTypes []string) (attestation.Attestor, error) {
+				pa, ok := a.(*ProductArchive)
+				if !ok {
+					return a, fmt.Errorf("unexpected attestor type: %T is not a product archive attestor", a)
+				}
+				WithIncludeMimeTypes(mimeTypes)(pa)
+				return pa, nil
+			},
+		),
+		registry.StringSliceConfigOption(
+			"exclude-mime-types",
+			"MIME types to exclude from the archive",
+			[]string{},
+			func(a attestation.Attestor, mimeTypes []string) (attestation.Attestor, error) {
+				pa, ok := a.(*ProductArchive)
+				if !ok {
+					return a, fmt.Errorf("unexpected attestor type: %T is not a product archive attestor", a)
+				}
+				WithExcludeMimeTypes(mimeTypes)(pa)
+				return pa, nil
+			},
+		),
+		registry.StringSliceConfigOption(
+			"include-glob",
+			"Glob patterns to include files",
+			[]string{},
+			func(a attestation.Attestor, patterns []string) (attestation.Attestor, error) {
+				pa, ok := a.(*ProductArchive)
+				if !ok {
+					return a, fmt.Errorf("unexpected attestor type: %T is not a product archive attestor", a)
+				}
+				WithIncludeGlob(patterns)(pa)
+				return pa, nil
+			},
+		),
+		registry.StringSliceConfigOption(
+			"exclude-glob",
+			"Glob patterns to exclude files",
+			[]string{},
+			func(a attestation.Attestor, patterns []string) (attestation.Attestor, error) {
+				pa, ok := a.(*ProductArchive)
+				if !ok {
+					return a, fmt.Errorf("unexpected attestor type: %T is not a product archive attestor", a)
+				}
+				WithExcludeGlob(patterns)(pa)
+				return pa, nil
+			},
+		),
+		registry.IntConfigOption(
+			"max-file-size",
+			"Maximum file size to include (in bytes)",
+			int(defaultMaxFileSize),
+			func(a attestation.Attestor, size int) (attestation.Attestor, error) {
+				pa, ok := a.(*ProductArchive)
+				if !ok {
+					return a, fmt.Errorf("unexpected attestor type: %T is not a product archive attestor", a)
+				}
+				WithMaxFileSize(int64(size))(pa)
+				return pa, nil
+			},
+		),
+	)
+}
+
+type Option func(*ProductArchive)
+
+func WithIncludeMimeTypes(mimeTypes []string) Option {
+	return func(pa *ProductArchive) {
+		pa.includeMimeTypes = mimeTypes
+	}
+}
+
+func WithExcludeMimeTypes(mimeTypes []string) Option {
+	return func(pa *ProductArchive) {
+		pa.excludeMimeTypes = mimeTypes
+	}
+}
+
+func WithIncludeGlob(patterns []string) Option {
+	return func(pa *ProductArchive) {
+		pa.includeGlob = patterns
+	}
+}
+
+func WithExcludeGlob(patterns []string) Option {
+	return func(pa *ProductArchive) {
+		pa.excludeGlob = patterns
+	}
+}
+
+func WithMaxFileSize(size int64) Option {
+	return func(pa *ProductArchive) {
+		pa.maxFileSize = size
+	}
+}
+
+type FileMetadata struct {
+	Mode       uint32            `json:"mode"`                 // File permissions
+	UID        uint32            `json:"uid"`                  // User ID
+	GID        uint32            `json:"gid"`                  // Group ID
+	Size       int64             `json:"size"`                 // File size in bytes
+	ModTime    int64             `json:"modTime"`              // Modification time (unix timestamp)
+	AccessTime int64             `json:"accessTime"`           // Access time (unix timestamp)
+	ChangeTime int64             `json:"changeTime"`           // Change time (unix timestamp)
+	BirthTime  *int64            `json:"birthTime,omitempty"`  // Creation time (if available)
+	Inode      uint64            `json:"inode"`                // Inode number
+	Nlink      uint64            `json:"nlink"`                // Number of hard links
+	IsDir      bool              `json:"isDir"`                // Is directory
+	IsRegular  bool              `json:"isRegular"`            // Is regular file
+	IsSymlink  bool              `json:"isSymlink"`            // Is symbolic link
+	LinkTarget string            `json:"linkTarget,omitempty"` // Symlink target
+	Xattrs     map[string]string `json:"xattrs,omitempty"`     // Extended attributes
+}
+
+type ArchivedProduct struct {
+	Name     string               `json:"name"`
+	Path     string               `json:"path"`
+	MimeType string               `json:"mimeType"`
+	Digest   cryptoutil.DigestSet `json:"digest"`
+	Content  []byte               `json:"content,omitempty"`
+	Metadata FileMetadata         `json:"metadata"`
+}
+
+type ProductArchive struct {
+	products         []ArchivedProduct
+	allProducts      map[string]attestation.Product
+	includeMimeTypes []string
+	excludeMimeTypes []string
+	includeGlob      []string
+	excludeGlob      []string
+	maxFileSize      int64
+	workingDir       string
+}
+
+func New(opts ...Option) *ProductArchive {
+	pa := &ProductArchive{
+		maxFileSize: defaultMaxFileSize,
+		products:    []ArchivedProduct{},
+	}
+
+	for _, opt := range opts {
+		opt(pa)
+	}
+
+	return pa
+}
+
+func (pa *ProductArchive) Name() string {
+	return Name
+}
+
+func (pa *ProductArchive) Type() string {
+	return Type
+}
+
+func (pa *ProductArchive) RunType() attestation.RunType {
+	return RunType
+}
+
+func (pa *ProductArchive) Schema() *jsonschema.Schema {
+	return jsonschema.Reflect(struct {
+		Products []ArchivedProduct `json:"products"`
+	}{})
+}
+
+func (pa *ProductArchive) Export() bool {
+	// Always export this attestor separately to avoid bloating the attestation collection
+	return true
+}
+
+// collectFileMetadata gathers comprehensive metadata about a file
+func collectFileMetadata(path string, info os.FileInfo) (FileMetadata, error) {
+	metadata := FileMetadata{
+		Size:      info.Size(),
+		Mode:      uint32(info.Mode()),
+		ModTime:   info.ModTime().Unix(),
+		IsDir:     info.IsDir(),
+		IsRegular: info.Mode().IsRegular(),
+		IsSymlink: info.Mode()&os.ModeSymlink != 0,
+	}
+
+	// Get system-specific metadata
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		metadata.UID = stat.Uid
+		metadata.GID = stat.Gid
+		metadata.Inode = stat.Ino
+		metadata.Nlink = uint64(stat.Nlink)
+
+		// Platform-specific times are handled in platform files
+		setFileTimes(&metadata, stat)
+
+		// Birth time (creation time) is platform-specific
+		if birthTime := getBirthTime(stat); birthTime != nil {
+			metadata.BirthTime = birthTime
+		}
+	}
+
+	// Handle symlinks
+	if metadata.IsSymlink {
+		target, err := os.Readlink(path)
+		if err == nil {
+			metadata.LinkTarget = target
+		}
+	}
+
+	// Get extended attributes (platform-specific)
+	xattrs, err := getXattrs(path)
+	if err == nil && len(xattrs) > 0 {
+		metadata.Xattrs = xattrs
+	}
+
+	return metadata, nil
+}
+
+// readFileContent reads file content if it's within the size limit.
+// For files larger than maxSize, it returns nil content without error.
+func readFileContent(path string, maxSize int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// If file is larger than maxSize, don't read content
+	if info.Size() > maxSize {
+		return nil, nil
+	}
+
+	// For files within size limit, read the content
+	content := make([]byte, info.Size())
+	_, err = io.ReadFull(file, content)
+	if err != nil {
+		return nil, err
+	}
+
+	return content, nil
+}
+
+func (pa *ProductArchive) Attest(ctx *attestation.AttestationContext) error {
+	pa.workingDir = ctx.WorkingDir()
+	pa.allProducts = ctx.Products()
+
+	// Compile glob patterns
+	includeGlobs := make([]glob.Glob, 0, len(pa.includeGlob))
+	for _, pattern := range pa.includeGlob {
+		g, err := glob.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("invalid include glob pattern %s: %w", pattern, err)
+		}
+		includeGlobs = append(includeGlobs, g)
+	}
+
+	excludeGlobs := make([]glob.Glob, 0, len(pa.excludeGlob))
+	for _, pattern := range pa.excludeGlob {
+		g, err := glob.Compile(pattern)
+		if err != nil {
+			return fmt.Errorf("invalid exclude glob pattern %s: %w", pattern, err)
+		}
+		excludeGlobs = append(excludeGlobs, g)
+	}
+
+	// Process products based on filters
+	for name, product := range pa.allProducts {
+		filePath := filepath.Join(pa.workingDir, name)
+
+		// Check glob patterns
+		if !pa.matchesGlobPatterns(name, includeGlobs, excludeGlobs) {
+			continue
+		}
+
+		// Check MIME type filters
+		if !pa.matchesMimeTypes(product.MimeType) {
+			continue
+		}
+
+		// Get file info and metadata
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			log.Warnf("Could not stat file %s: %v", filePath, err)
+			continue
+		}
+
+		// Skip files that exceed max size
+		if fileInfo.Size() > pa.maxFileSize {
+			log.Debugf("Skipping file %s: size %d exceeds max %d", name, fileInfo.Size(), pa.maxFileSize)
+			continue
+		}
+
+		// Collect file metadata
+		metadata, err := collectFileMetadata(filePath, fileInfo)
+		if err != nil {
+			log.Warnf("Could not collect metadata for file %s: %v", filePath, err)
+			// Continue with partial metadata
+		}
+
+		// Read file content (now we know it's within size limit)
+		content, err := readFileContent(filePath, pa.maxFileSize)
+		if err != nil {
+			log.Warnf("Could not read file %s: %v", filePath, err)
+		}
+
+		archivedProduct := ArchivedProduct{
+			Name:     name,
+			Path:     filePath,
+			MimeType: product.MimeType,
+			Digest:   product.Digest,
+			Content:  content,
+			Metadata: metadata,
+		}
+
+		pa.products = append(pa.products, archivedProduct)
+	}
+
+	log.Infof("Archived %d products out of %d total", len(pa.products), len(pa.allProducts))
+	return nil
+}
+
+func (pa *ProductArchive) matchesGlobPatterns(name string, includeGlobs, excludeGlobs []glob.Glob) bool {
+	// If exclude patterns are specified and match, exclude the file
+	for _, g := range excludeGlobs {
+		if g.Match(name) {
+			return false
+		}
+	}
+
+	// If no include patterns specified, include by default
+	if len(includeGlobs) == 0 {
+		return true
+	}
+
+	// If include patterns are specified, at least one must match
+	for _, g := range includeGlobs {
+		if g.Match(name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (pa *ProductArchive) matchesMimeTypes(mimeType string) bool {
+	// If exclude MIME types are specified and match, exclude the file
+	for _, excludeType := range pa.excludeMimeTypes {
+		if mimeType == excludeType {
+			return false
+		}
+	}
+
+	// If no include MIME types specified, include by default
+	if len(pa.includeMimeTypes) == 0 {
+		return true
+	}
+
+	// If include MIME types are specified, must match one
+	for _, includeType := range pa.includeMimeTypes {
+		if mimeType == includeType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (pa *ProductArchive) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Products []ArchivedProduct `json:"products"`
+	}{
+		Products: pa.products,
+	})
+}
+
+func (pa *ProductArchive) UnmarshalJSON(data []byte) error {
+	var temp struct {
+		Products []ArchivedProduct `json:"products"`
+	}
+
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	pa.products = temp.Products
+	return nil
+}
+
+// ExportedAttestations returns individual attestations for each archived product
+func (pa *ProductArchive) ExportedAttestations() []attestation.ExportedAttestation {
+	attestations := make([]attestation.ExportedAttestation, 0, len(pa.products))
+
+	for _, product := range pa.products {
+		// Create a single-product attestation
+		singleProduct := struct {
+			Products []ArchivedProduct `json:"products"`
+		}{
+			Products: []ArchivedProduct{product},
+		}
+
+		// Create subjects for this specific product
+		subjects := make(map[string]cryptoutil.DigestSet)
+		subjects[fmt.Sprintf("file:%s", product.Name)] = product.Digest
+
+		attestations = append(attestations, attestation.ExportedAttestation{
+			Predicate:     singleProduct,
+			PredicateType: Type,
+			Subjects:      subjects,
+			Name:          product.Name,
+		})
+	}
+
+	return attestations
+}

--- a/attestation/productarchive/productarchive_test.go
+++ b/attestation/productarchive/productarchive_test.go
@@ -1,0 +1,422 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package productarchive
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProductArchive_Filters(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create test files
+	testFiles := map[string]struct {
+		content  string
+		mimeType string
+	}{
+		"test.txt":  {"hello world", "text/plain"},
+		"test.json": {`{"test": true}`, "application/json"},
+		"large.bin": {string(make([]byte, 200*1024*1024)), "application/octet-stream"}, // 200MB
+		"README.md": {"# Test", "text/markdown"},
+		"image.png": {"fake png content", "image/png"},
+	}
+
+	products := make(map[string]attestation.Product)
+	for name, file := range testFiles {
+		path := filepath.Join(tmpDir, name)
+		err := os.WriteFile(path, []byte(file.content), 0644)
+		require.NoError(t, err)
+
+		digestSet, _ := cryptoutil.NewDigestSet(map[string]string{
+			"sha256": "test-digest",
+		})
+		products[name] = attestation.Product{
+			MimeType: file.mimeType,
+			Digest:   digestSet,
+		}
+	}
+
+	tests := []struct {
+		name             string
+		opts             []Option
+		expectedProducts []string
+	}{
+		{
+			name: "include by mime type",
+			opts: []Option{
+				WithIncludeMimeTypes([]string{"text/plain", "application/json"}),
+			},
+			expectedProducts: []string{"test.txt", "test.json"},
+		},
+		{
+			name: "exclude by mime type",
+			opts: []Option{
+				WithExcludeMimeTypes([]string{"image/png"}),
+			},
+			expectedProducts: []string{"test.txt", "test.json", "README.md"},
+		},
+		{
+			name: "include by glob",
+			opts: []Option{
+				WithIncludeGlob([]string{"*.txt", "*.md"}),
+			},
+			expectedProducts: []string{"test.txt", "README.md"},
+		},
+		{
+			name: "exclude by glob",
+			opts: []Option{
+				WithExcludeGlob([]string{"README.*"}),
+			},
+			expectedProducts: []string{"test.txt", "test.json", "image.png"},
+		},
+		{
+			name: "max file size",
+			opts: []Option{
+				WithMaxFileSize(1024 * 1024), // 1MB
+			},
+			expectedProducts: []string{"test.txt", "test.json", "README.md", "image.png"},
+		},
+		{
+			name: "combined filters",
+			opts: []Option{
+				WithIncludeMimeTypes([]string{"text/plain", "text/markdown"}),
+				WithExcludeGlob([]string{"README.*"}),
+			},
+			expectedProducts: []string{"test.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pa := New(tt.opts...)
+
+			// Create a mock product attestor
+			mockProducer := &mockProductAttestor{products: products}
+
+			// Create attestation context and run all attestors
+			ctx, err := attestation.NewContext("test", []attestation.Attestor{mockProducer, pa}, attestation.WithWorkingDir(tmpDir))
+			require.NoError(t, err)
+
+			// Run all attestors through the context - this will populate products
+			err = ctx.RunAttestors()
+			require.NoError(t, err)
+
+			archivedNames := make([]string, 0, len(pa.products))
+			for _, p := range pa.products {
+				archivedNames = append(archivedNames, p.Name)
+			}
+
+			assert.ElementsMatch(t, tt.expectedProducts, archivedNames)
+		})
+	}
+}
+
+func TestProductArchive_Export(t *testing.T) {
+	pa := New()
+	assert.True(t, pa.Export())
+}
+
+func TestProductArchive_Schema(t *testing.T) {
+	pa := New()
+	schema := pa.Schema()
+	assert.NotNil(t, schema)
+}
+
+func TestProductArchive_MultiExporter(t *testing.T) {
+	pa := New()
+	digest1, _ := cryptoutil.NewDigestSet(map[string]string{
+		"sha256": "abc123",
+	})
+	digest2, _ := cryptoutil.NewDigestSet(map[string]string{
+		"sha256": "def456",
+	})
+	pa.products = []ArchivedProduct{
+		{
+			Name:     "test.txt",
+			Path:     "/tmp/test.txt",
+			MimeType: "text/plain",
+			Digest:   digest1,
+			Content:  []byte("test content"),
+			Metadata: FileMetadata{Size: 12},
+		},
+		{
+			Name:     "test.json",
+			Path:     "/tmp/test.json",
+			MimeType: "application/json",
+			Digest:   digest2,
+			Content:  []byte(`{"test": true}`),
+			Metadata: FileMetadata{Size: 14},
+		},
+	}
+
+	// Test Export returns true
+	assert.True(t, pa.Export())
+
+	// Get exported attestations
+	attestations := pa.ExportedAttestations()
+	assert.Len(t, attestations, 2)
+
+	// Verify first attestation
+	att1 := attestations[0]
+	assert.Equal(t, "test.txt", att1.Name)
+	assert.Equal(t, Type, att1.PredicateType)
+	assert.Len(t, att1.Subjects, 1)
+	assert.NotNil(t, att1.Subjects["file:test.txt"])
+
+	// Verify predicate contains only one product
+	pred1, ok := att1.Predicate.(struct {
+		Products []ArchivedProduct `json:"products"`
+	})
+	assert.True(t, ok)
+	assert.Len(t, pred1.Products, 1)
+	assert.Equal(t, "test.txt", pred1.Products[0].Name)
+
+	// Verify second attestation
+	att2 := attestations[1]
+	assert.Equal(t, "test.json", att2.Name)
+	assert.Len(t, att2.Subjects, 1)
+	assert.NotNil(t, att2.Subjects["file:test.json"])
+}
+
+func TestProductArchive_BinaryFiles(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create test binary file with known content
+	binaryContent := make([]byte, 1024) // 1KB binary file
+	for i := range binaryContent {
+		binaryContent[i] = byte(i % 256)
+	}
+
+	binaryPath := filepath.Join(tmpDir, "test.bin")
+	err := os.WriteFile(binaryPath, binaryContent, 0644)
+	require.NoError(t, err)
+
+	// Create a large binary file that exceeds the limit
+	largeBinaryContent := make([]byte, 1024*1024) // 1MB
+	largeBinaryPath := filepath.Join(tmpDir, "large.bin")
+	err = os.WriteFile(largeBinaryPath, largeBinaryContent, 0644)
+	require.NoError(t, err)
+
+	// Create products map
+	digestSet, _ := cryptoutil.NewDigestSet(map[string]string{
+		"sha256": "test-binary-digest",
+	})
+	largeDigestSet, _ := cryptoutil.NewDigestSet(map[string]string{
+		"sha256": "test-large-binary-digest",
+	})
+
+	products := map[string]attestation.Product{
+		"test.bin": {
+			MimeType: "application/octet-stream",
+			Digest:   digestSet,
+		},
+		"large.bin": {
+			MimeType: "application/octet-stream",
+			Digest:   largeDigestSet,
+		},
+	}
+
+	// Test with different size limits
+	tests := []struct {
+		name          string
+		maxFileSize   int64
+		expectedFiles []string
+		checkContent  bool
+	}{
+		{
+			name:          "include small binary",
+			maxFileSize:   10 * 1024, // 10KB limit
+			expectedFiles: []string{"test.bin"},
+			checkContent:  true,
+		},
+		{
+			name:          "include all binaries",
+			maxFileSize:   2 * 1024 * 1024, // 2MB limit
+			expectedFiles: []string{"test.bin", "large.bin"},
+			checkContent:  false, // Don't check content for large file test
+		},
+		{
+			name:          "exclude large binary",
+			maxFileSize:   512 * 1024, // 512KB limit
+			expectedFiles: []string{"test.bin"},
+			checkContent:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pa := New(WithMaxFileSize(tt.maxFileSize))
+
+			// Create mock producer and context
+			mockProducer := &mockProductAttestor{products: products}
+			ctx, err := attestation.NewContext("test", []attestation.Attestor{mockProducer, pa}, attestation.WithWorkingDir(tmpDir))
+			require.NoError(t, err)
+
+			// Run attestors
+			err = ctx.RunAttestors()
+			require.NoError(t, err)
+
+			// Check results
+			assert.Len(t, pa.products, len(tt.expectedFiles))
+
+			foundFiles := make(map[string]bool)
+			for _, p := range pa.products {
+				foundFiles[p.Name] = true
+
+				// Verify binary content was included and is correct
+				if tt.checkContent && p.Name == "test.bin" {
+					assert.NotNil(t, p.Content)
+					assert.Equal(t, binaryContent, p.Content)
+				}
+			}
+
+			for _, expectedFile := range tt.expectedFiles {
+				assert.True(t, foundFiles[expectedFile], "Expected file %s not found", expectedFile)
+			}
+		})
+	}
+}
+
+func TestProductArchive_JSONEncoding(t *testing.T) {
+	// Test that binary content is properly base64 encoded in JSON
+	binaryContent := []byte{0xFF, 0xFE, 0xFD, 0x00, 0x01, 0x02, 0x03}
+
+	digest, _ := cryptoutil.NewDigestSet(map[string]string{
+		"sha256": "test-digest",
+	})
+
+	pa := New()
+	pa.products = []ArchivedProduct{
+		{
+			Name:     "binary.dat",
+			Path:     "/tmp/binary.dat",
+			MimeType: "application/octet-stream",
+			Digest:   digest,
+			Content:  binaryContent,
+			Metadata: FileMetadata{
+				Size: int64(len(binaryContent)),
+			},
+		},
+	}
+
+	// Marshal to JSON
+	jsonData, err := pa.MarshalJSON()
+	require.NoError(t, err)
+
+	// Check that it's valid JSON
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonData, &result)
+	require.NoError(t, err)
+
+	// Verify the content is base64 encoded
+	products := result["products"].([]interface{})
+	product := products[0].(map[string]interface{})
+	contentStr := product["content"].(string)
+
+	// Decode the base64
+	decodedContent, err := base64.StdEncoding.DecodeString(contentStr)
+	require.NoError(t, err)
+
+	// Verify it matches original
+	assert.Equal(t, binaryContent, decodedContent)
+}
+
+// mockProductAttestor is a test helper that implements the Producer interface
+type mockProductAttestor struct {
+	products map[string]attestation.Product
+}
+
+func (m *mockProductAttestor) Name() string {
+	return "mock-product"
+}
+
+func (m *mockProductAttestor) Type() string {
+	return "mock-product-type"
+}
+
+func (m *mockProductAttestor) RunType() attestation.RunType {
+	return attestation.ProductRunType
+}
+
+func (m *mockProductAttestor) Attest(ctx *attestation.AttestationContext) error {
+	return nil
+}
+
+func (m *mockProductAttestor) Schema() *jsonschema.Schema {
+	return &jsonschema.Schema{}
+}
+
+func (m *mockProductAttestor) Products() map[string]attestation.Product {
+	return m.products
+}
+
+func TestProductArchive_Metadata(t *testing.T) {
+	// Create a temporary directory and file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "metadata-test.txt")
+	content := []byte("test content for metadata")
+	err := os.WriteFile(testFile, content, 0644)
+	require.NoError(t, err)
+
+	// Create a symlink
+	symlinkPath := filepath.Join(tmpDir, "test-link")
+	err = os.Symlink(testFile, symlinkPath)
+	require.NoError(t, err)
+
+	// Get file info
+	info, err := os.Stat(testFile)
+	require.NoError(t, err)
+
+	// Get symlink info
+	linkInfo, err := os.Lstat(symlinkPath)
+	require.NoError(t, err)
+
+	// Collect metadata
+	metadata, err := collectFileMetadata(testFile, info)
+	require.NoError(t, err)
+
+	// Verify basic metadata
+	assert.Equal(t, int64(len(content)), metadata.Size)
+	assert.Equal(t, uint32(0644), metadata.Mode&0777) // Check permission bits
+	assert.True(t, metadata.IsRegular)
+	assert.False(t, metadata.IsDir)
+	assert.False(t, metadata.IsSymlink)
+	assert.Greater(t, metadata.ModTime, int64(0))
+
+	// Platform-specific checks
+	if metadata.UID != 0 || metadata.GID != 0 {
+		// We got platform-specific data
+		assert.Greater(t, metadata.Inode, uint64(0))
+		assert.Greater(t, metadata.Nlink, uint64(0))
+	}
+
+	// Test symlink metadata
+	linkMetadata, err := collectFileMetadata(symlinkPath, linkInfo)
+	require.NoError(t, err)
+	assert.True(t, linkMetadata.IsSymlink)
+	assert.Equal(t, testFile, linkMetadata.LinkTarget)
+}

--- a/imports.go
+++ b/imports.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/in-toto/go-witness/attestation/oci"
 	_ "github.com/in-toto/go-witness/attestation/policyverify"
 	_ "github.com/in-toto/go-witness/attestation/product"
+	_ "github.com/in-toto/go-witness/attestation/productarchive"
 	_ "github.com/in-toto/go-witness/attestation/sarif"
 	_ "github.com/in-toto/go-witness/attestation/sbom"
 	_ "github.com/in-toto/go-witness/attestation/secretscan"

--- a/schemagen/product-archive.json
+++ b/schemagen/product-archive.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
+    "ArchivedProduct": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "mimeType": {
+          "type": "string"
+        },
+        "digest": {
+          "$ref": "#/$defs/DigestSet"
+        },
+        "content": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "metadata": {
+          "$ref": "#/$defs/FileMetadata"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "path",
+        "mimeType",
+        "digest",
+        "metadata"
+      ]
+    },
+    "DigestSet": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "FileMetadata": {
+      "properties": {
+        "mode": {
+          "type": "integer"
+        },
+        "uid": {
+          "type": "integer"
+        },
+        "gid": {
+          "type": "integer"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "modTime": {
+          "type": "integer"
+        },
+        "accessTime": {
+          "type": "integer"
+        },
+        "changeTime": {
+          "type": "integer"
+        },
+        "birthTime": {
+          "type": "integer"
+        },
+        "inode": {
+          "type": "integer"
+        },
+        "nlink": {
+          "type": "integer"
+        },
+        "isDir": {
+          "type": "boolean"
+        },
+        "isRegular": {
+          "type": "boolean"
+        },
+        "isSymlink": {
+          "type": "boolean"
+        },
+        "linkTarget": {
+          "type": "string"
+        },
+        "xattrs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mode",
+        "uid",
+        "gid",
+        "size",
+        "modTime",
+        "accessTime",
+        "changeTime",
+        "inode",
+        "nlink",
+        "isDir",
+        "isRegular",
+        "isSymlink"
+      ]
+    }
+  },
+  "properties": {
+    "products": {
+      "items": {
+        "$ref": "#/$defs/ArchivedProduct"
+      },
+      "type": "array"
+    }
+  },
+  "additionalProperties": false,
+  "type": "object",
+  "required": [
+    "products"
+  ]
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `product-archive` attestor that creates individual attestations for each output file produced during a build. Unlike other attestors that create a single attestation, this one leverages the MultiExporter interface to generate one attestation per archived product.

## Dependencies

⚠️ **This PR depends on #507 (MultiExporter interface) and should be merged after it.**

## Features

### Filtering Capabilities
- **MIME Type Filtering**: Include/exclude files based on MIME type
- **Glob Pattern Filtering**: Include/exclude files using glob patterns
- **File Size Filtering**: Skip files exceeding a configurable size limit (default: 100MB)

### Comprehensive Metadata Collection
- File permissions and mode
- User/Group IDs
- Timestamps (modified, accessed, changed, creation where available)
- Inode and hard link information
- File type indicators (regular, directory, symlink)
- Symlink targets
- Extended attributes (xattrs) on supported platforms

### Platform Support
- **macOS**: Full metadata including birth time and extended attributes
- **Linux**: Full metadata except birth time, with extended attributes
- **Other platforms**: Basic metadata support

### Content Handling
- Includes file content for files within size limit
- Content is base64-encoded in JSON output
- Large files are included with metadata only (no content)

## Configuration Options

```bash
witness run -- --attestor-product-archive-include-mime-types="text/plain,application/json" \
              --attestor-product-archive-exclude-glob="*.tmp,*.log" \
              --attestor-product-archive-max-file-size=50000000
```

## Example Output Structure

When running with product-archive attestor on multiple files:
```
Results:
- attestation-collection.json (contains all attestors except product-archive)
- product-archive/output1.bin (individual attestation)
- product-archive/output2.txt (individual attestation)
- product-archive/config.json (individual attestation)
```

Each attestation contains:
```json
{
  "products": [{
    "name": "output1.bin",
    "path": "/build/output1.bin",
    "mimeType": "application/octet-stream",
    "digest": {
      "sha256": "abc123..."
    },
    "content": "base64-encoded-content...",
    "metadata": {
      "mode": 420,
      "uid": 1000,
      "gid": 1000,
      "size": 1024,
      "modTime": 1234567890,
      "accessTime": 1234567890,
      "changeTime": 1234567890,
      "inode": 12345,
      "nlink": 1,
      "isRegular": true,
      "isDir": false,
      "isSymlink": false
    }
  }]
}
```

## Testing

- Comprehensive test coverage for all filtering options
- Binary file handling tests
- Platform-specific metadata collection tests
- JSON encoding/decoding tests

## Benefits

- **Granular Attestations**: Each file gets its own attestation
- **Independent Verification**: Files can be verified individually
- **Efficient Distribution**: Only needed attestations need to be shared
- **Rich Metadata**: Comprehensive file system information for forensics
- **Scalable**: Avoids creating massive single attestations