### PR TITLE
log failed attestor name for better debugging

### DIFF
--- a/run.go
+++ b/run.go
@@ -138,7 +138,8 @@ func run(stepName string, opts []RunOption) ([]RunResult, error) {
 	errs := make([]error, 0)
 	for _, r := range runCtx.CompletedAttestors() {
 		if r.Error != nil {
-			errs = append(errs, r.Error)
+			wrappedErr := fmt.Errorf("attestor %s failed: %w", r.Attestor.Name(), r.Error)
+			errs = append(errs, wrappedErr)
 		} else {
 			// Check if this is a MultiExporter first
 			if multiExporter, ok := r.Attestor.(attestation.MultiExporter); ok {


### PR DESCRIPTION
## What this PR does / why we need it
Instead of generic error messages, each attestor error now includes the specific attestor name that failed

Description
When the witness CLI logs log.Debugf("attestor execution failed: %v", err), it will now show messages like "attestor git failed: repository does not exist" instead of just "repository does not exist"
