### PR TITLE
fix: omnitrail on Windows breaks build of witness

### DIFF
--- a/imports.go
+++ b/imports.go
@@ -34,7 +34,6 @@ import (
 	_ "github.com/in-toto/go-witness/attestation/material"
 	_ "github.com/in-toto/go-witness/attestation/maven"
 	_ "github.com/in-toto/go-witness/attestation/oci"
-	_ "github.com/in-toto/go-witness/attestation/omnitrail"
 	_ "github.com/in-toto/go-witness/attestation/policyverify"
 	_ "github.com/in-toto/go-witness/attestation/product"
 	_ "github.com/in-toto/go-witness/attestation/sarif"


### PR DESCRIPTION
## What this PR does / why we need it

This was accidentally added into the normal imports.go and should only be in the non-windows imports.