### PR TITLE
feat: add configuration attestor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,13 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 test: ## Run the go unit tests
 	go test -v -coverprofile=profile.cov -covermode=atomic ./...
 
+
 integration-test:
 	go test -v -coverprofile=profile.cov -covermode=atomic -tags=integration ./...
+
+.PHONY: coverage
+coverage: ## Show the coverage
+	go tool cover -html=profile.cov
 
 .PHONY: schema
 schema: ## Generate the attestor schema json files

--- a/attestation/configuration/configuration.go
+++ b/attestation/configuration/configuration.go
@@ -1,0 +1,184 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configuration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/invopop/jsonschema"
+)
+
+const (
+	Name    = "configuration"
+	Type    = "https://witness.dev/attestations/configuration/v0.1"
+	RunType = attestation.PreMaterialRunType
+)
+
+// This is a hacky way to create a compile time error in case the attestor
+// doesn't implement the expected interfaces.
+var (
+	_ attestation.Attestor  = &Attestor{}
+	_ ConfigurationAttestor = &Attestor{}
+)
+
+type ConfigurationAttestor interface {
+	// Attestor
+	Name() string
+	Type() string
+	RunType() attestation.RunType
+	Attest(ctx *attestation.AttestationContext) error
+	Data() *Attestor
+}
+
+func init() {
+	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor { return New() })
+}
+
+type Attestor struct {
+	Flags        map[string]string `json:"flags,omitempty"`
+	ConfigPath   string            `json:"config_path,omitempty"`
+	ConfigDigest string            `json:"config_digest,omitempty"`
+	WorkingDir   string            `json:"working_directory,omitempty"`
+
+	osArgs func() []string
+}
+
+type Option func(*Attestor)
+
+func WithCustomArgs(osArgs func() []string) Option {
+	return func(a *Attestor) {
+		a.osArgs = osArgs
+	}
+}
+
+func New(opts ...Option) *Attestor {
+	attestor := &Attestor{}
+
+	attestor.osArgs = func() []string {
+		return os.Args
+	}
+
+	for _, opt := range opts {
+		opt(attestor)
+	}
+
+	return attestor
+}
+
+func (a *Attestor) Name() string {
+	return Name
+}
+
+func (a *Attestor) Type() string {
+	return Type
+}
+
+func (a *Attestor) RunType() attestation.RunType {
+	return RunType
+}
+
+func (a *Attestor) Schema() *jsonschema.Schema {
+	return jsonschema.Reflect(&a)
+}
+
+func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
+	args := a.osArgs()
+	witnessArgs := extractWitnessArgs(args)
+	a.Flags = parseFlags(witnessArgs)
+
+	// Capture working directory
+	if wd, err := os.Getwd(); err == nil {
+		a.WorkingDir = wd
+	}
+
+	// Config path: flag or default
+	if v, ok := a.Flags["config"]; ok && v != "" {
+		a.ConfigPath = v
+	} else if v, ok := a.Flags["c"]; ok && v != "" {
+		a.ConfigPath = v
+	} else {
+		a.ConfigPath = ".witness.yaml"
+	}
+
+	// Config digest if file exists
+	if data, err := os.ReadFile(a.ConfigPath); err == nil {
+		sum := sha256.Sum256(data)
+		a.ConfigDigest = hex.EncodeToString(sum[:])
+	}
+
+	return nil
+}
+
+// extractWitnessArgs splits the command line at "--" and returns only the witness portion
+// Example: ["witness", "run", "-a", "slsa", "--", "go", "build", "."] -> ["witness", "run", "-a", "slsa"]
+func extractWitnessArgs(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return args[:i]
+		}
+	}
+	return args
+}
+
+// parseFlags parses command line flags into a map
+func parseFlags(cmd []string) map[string]string {
+	flags := make(map[string]string)
+
+	for i := 1; i < len(cmd); i++ {
+		arg := cmd[i]
+
+		if strings.HasPrefix(arg, "--") {
+			key := strings.TrimPrefix(arg, "--")
+
+			if strings.Contains(key, "=") {
+				parts := strings.SplitN(key, "=", 2)
+				flags[parts[0]] = parts[1]
+				continue
+			}
+
+			if i+1 < len(cmd) && !strings.HasPrefix(cmd[i+1], "-") {
+				flags[key] = cmd[i+1]
+				i++
+			} else {
+				flags[key] = "true"
+			}
+		} else if strings.HasPrefix(arg, "-") && len(arg) > 1 && !strings.HasPrefix(arg, "--") {
+			key := strings.TrimPrefix(arg, "-")
+
+			if strings.Contains(key, "=") {
+				parts := strings.SplitN(key, "=", 2)
+				flags[parts[0]] = parts[1]
+				continue
+			}
+
+			if i+1 < len(cmd) && !strings.HasPrefix(cmd[i+1], "-") {
+				flags[key] = cmd[i+1]
+				i++
+			} else {
+				flags[key] = "true"
+			}
+		}
+	}
+
+	return flags
+}
+
+func (a *Attestor) Data() *Attestor {
+	return a
+}

--- a/attestation/configuration/configuration.go
+++ b/attestation/configuration/configuration.go
@@ -15,7 +15,6 @@
 package configuration
 
 import (
-	"crypto"
 	"os"
 	"strings"
 
@@ -120,9 +119,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 
 	// Config digest and content if file exists
 	if data, err := os.ReadFile(a.ConfigPath); err == nil {
-		digestSet, err := cryptoutil.CalculateDigestSetFromBytes(data, []cryptoutil.DigestValue{
-			{Hash: crypto.SHA256, GitOID: false, DirHash: false},
-		})
+		digestSet, err := cryptoutil.CalculateDigestSetFromBytes(data, ctx.Hashes())
 		if err == nil {
 			a.ConfigDigest = digestSet
 		}

--- a/attestation/configuration/configuration.go
+++ b/attestation/configuration/configuration.go
@@ -108,26 +108,26 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		a.WorkingDir = wd
 	}
 
-	// Config path: flag or default
+	// Config path is only set when explicitly passed via --config/-c.
+	// Witness removed default loading of .witness.yaml for security reasons,
+	// so an empty ConfigPath distinguishes "no config used" from a loaded file.
 	if v, ok := a.Flags["config"]; ok && v != "" {
 		a.ConfigPath = v
 	} else if v, ok := a.Flags["c"]; ok && v != "" {
 		a.ConfigPath = v
-	} else {
-		a.ConfigPath = ".witness.yaml"
 	}
 
-	// Config digest and content if file exists
-	if data, err := os.ReadFile(a.ConfigPath); err == nil {
-		digestSet, err := cryptoutil.CalculateDigestSetFromBytes(data, ctx.Hashes())
-		if err == nil {
-			a.ConfigDigest = digestSet
-		}
+	if a.ConfigPath != "" {
+		if data, err := os.ReadFile(a.ConfigPath); err == nil {
+			digestSet, err := cryptoutil.CalculateDigestSetFromBytes(data, ctx.Hashes())
+			if err == nil {
+				a.ConfigDigest = digestSet
+			}
 
-		// Parse and store config content
-		var configData map[string]interface{}
-		if err := yaml.Unmarshal(data, &configData); err == nil {
-			a.ConfigContent = configData
+			var configData map[string]interface{}
+			if err := yaml.Unmarshal(data, &configData); err == nil {
+				a.ConfigContent = configData
+			}
 		}
 	}
 

--- a/attestation/configuration/configuration.go
+++ b/attestation/configuration/configuration.go
@@ -104,7 +104,9 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 	a.Flags = parseFlags(witnessArgs)
 
 	// Capture working directory
-	if wd, err := os.Getwd(); err == nil {
+	if wd := ctx.WorkingDir(); wd != "" {
+		a.WorkingDir = wd
+	} else if wd, err := os.Getwd(); err == nil {
 		a.WorkingDir = wd
 	}
 

--- a/attestation/configuration/configuration.go
+++ b/attestation/configuration/configuration.go
@@ -15,8 +15,8 @@
 package configuration
 
 import (
+	"fmt"
 	"os"
-	"strings"
 
 	"github.com/in-toto/go-witness/attestation"
 	"github.com/in-toto/go-witness/cryptoutil"
@@ -50,31 +50,49 @@ func init() {
 	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor { return New() })
 }
 
-type Attestor struct {
-	Flags         map[string]string      `json:"flags,omitempty"`
-	ConfigPath    string                 `json:"config_path,omitempty"`
-	ConfigDigest  cryptoutil.DigestSet   `json:"config_digest,omitempty"`
-	ConfigContent map[string]interface{} `json:"config_content,omitempty"`
-	WorkingDir    string                 `json:"working_directory,omitempty"`
+// ResolvedValue is a single configuration value as resolved by the frontend,
+// with its source: "commandline", "config", "env", or "default".
+type ResolvedValue struct {
+	Value  any    `json:"value"`
+	Source string `json:"source,omitempty"`
+}
 
-	osArgs func() []string
+type Attestor struct {
+	CommandLine   []string                  `json:"command_line,omitempty"`
+	Resolved      map[string]ResolvedValue  `json:"resolved,omitempty"`
+	ConfigPath    string                    `json:"config_path,omitempty"`
+	ConfigDigest  cryptoutil.DigestSet      `json:"config_digest,omitempty"`
+	ConfigContent map[string]any            `json:"config_content,omitempty"`
+	Attestors     map[string]map[string]any `json:"attestors,omitempty"`
+	WorkingDir    string                    `json:"working_directory,omitempty"`
 }
 
 type Option func(*Attestor)
 
-func WithCustomArgs(osArgs func() []string) Option {
+// WithCommandLine records the frontend's raw argv verbatim. The attestor never
+// reads os.Args itself so library consumers don't leak their host process args.
+func WithCommandLine(args []string) Option {
 	return func(a *Attestor) {
-		a.osArgs = osArgs
+		a.CommandLine = args
+	}
+}
+
+// WithResolvedConfig records the fully-merged config as resolved by the
+// frontend (e.g. pflag/viper for the witness CLI).
+func WithResolvedConfig(resolved map[string]ResolvedValue) Option {
+	return func(a *Attestor) {
+		a.Resolved = resolved
+	}
+}
+
+func WithConfigFile(path string) Option {
+	return func(a *Attestor) {
+		a.ConfigPath = path
 	}
 }
 
 func New(opts ...Option) *Attestor {
 	attestor := &Attestor{}
-
-	attestor.osArgs = func() []string {
-		return os.Args
-	}
-
 	for _, opt := range opts {
 		opt(attestor)
 	}
@@ -99,95 +117,45 @@ func (a *Attestor) Schema() *jsonschema.Schema {
 }
 
 func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
-	args := a.osArgs()
-	witnessArgs := extractWitnessArgs(args)
-	a.Flags = parseFlags(witnessArgs)
-
-	// Capture working directory
 	if wd := ctx.WorkingDir(); wd != "" {
 		a.WorkingDir = wd
 	} else if wd, err := os.Getwd(); err == nil {
 		a.WorkingDir = wd
 	}
 
-	// Config path is only set when explicitly passed via --config/-c.
-	// Witness removed default loading of .witness.yaml for security reasons,
-	// so an empty ConfigPath distinguishes "no config used" from a loaded file.
-	if v, ok := a.Flags["config"]; ok && v != "" {
-		a.ConfigPath = v
-	} else if v, ok := a.Flags["c"]; ok && v != "" {
-		a.ConfigPath = v
+	if a.ConfigPath != "" {
+		data, err := os.ReadFile(a.ConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to read config file %v: %w", a.ConfigPath, err)
+		}
+
+		digestSet, err := cryptoutil.CalculateDigestSetFromBytes(data, ctx.Hashes())
+		if err != nil {
+			return fmt.Errorf("failed to digest config file %v: %w", a.ConfigPath, err)
+		}
+		a.ConfigDigest = digestSet
+
+		var configData map[string]any
+		if err := yaml.Unmarshal(data, &configData); err != nil {
+			return fmt.Errorf("failed to parse config file %v: %w", a.ConfigPath, err)
+		}
+		a.ConfigContent = configData
 	}
 
-	if a.ConfigPath != "" {
-		if data, err := os.ReadFile(a.ConfigPath); err == nil {
-			digestSet, err := cryptoutil.CalculateDigestSetFromBytes(data, ctx.Hashes())
-			if err == nil {
-				a.ConfigDigest = digestSet
-			}
+	for _, att := range ctx.Attestors() {
+		if att.Name() == Name {
+			continue
+		}
 
-			var configData map[string]interface{}
-			if err := yaml.Unmarshal(data, &configData); err == nil {
-				a.ConfigContent = configData
+		if configurer, ok := att.(attestation.Configurer); ok {
+			if a.Attestors == nil {
+				a.Attestors = make(map[string]map[string]any)
 			}
+			a.Attestors[att.Name()] = configurer.Configuration()
 		}
 	}
 
 	return nil
-}
-
-// extractWitnessArgs splits the command line at "--" and returns only the witness portion
-// Example: ["witness", "run", "-a", "slsa", "--", "go", "build", "."] -> ["witness", "run", "-a", "slsa"]
-func extractWitnessArgs(args []string) []string {
-	for i, arg := range args {
-		if arg == "--" {
-			return args[:i]
-		}
-	}
-	return args
-}
-
-// parseFlags parses command line flags into a map
-func parseFlags(cmd []string) map[string]string {
-	flags := make(map[string]string)
-
-	for i := 1; i < len(cmd); i++ {
-		arg := cmd[i]
-
-		if strings.HasPrefix(arg, "--") {
-			key := strings.TrimPrefix(arg, "--")
-
-			if strings.Contains(key, "=") {
-				parts := strings.SplitN(key, "=", 2)
-				flags[parts[0]] = parts[1]
-				continue
-			}
-
-			if i+1 < len(cmd) && !strings.HasPrefix(cmd[i+1], "-") {
-				flags[key] = cmd[i+1]
-				i++
-			} else {
-				flags[key] = "true"
-			}
-		} else if strings.HasPrefix(arg, "-") && len(arg) > 1 && !strings.HasPrefix(arg, "--") {
-			key := strings.TrimPrefix(arg, "-")
-
-			if strings.Contains(key, "=") {
-				parts := strings.SplitN(key, "=", 2)
-				flags[parts[0]] = parts[1]
-				continue
-			}
-
-			if i+1 < len(cmd) && !strings.HasPrefix(cmd[i+1], "-") {
-				flags[key] = cmd[i+1]
-				i++
-			} else {
-				flags[key] = "true"
-			}
-		}
-	}
-
-	return flags
 }
 
 func (a *Attestor) Data() *Attestor {

--- a/attestation/configuration/configuration_test.go
+++ b/attestation/configuration/configuration_test.go
@@ -252,10 +252,6 @@ verify:
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	oldWd, err := os.Getwd()
-	require.NoError(t, err)
-	defer os.Chdir(oldWd)
-
 	err = os.Chdir(tempDir)
 	require.NoError(t, err)
 

--- a/attestation/configuration/configuration_test.go
+++ b/attestation/configuration/configuration_test.go
@@ -252,8 +252,9 @@ verify:
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	err = os.Chdir(tempDir)
-	require.NoError(t, err)
+	oldDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(tempDir))
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
 
 	attestor := New(WithCustomArgs(func() []string {
 		return []string{"witness", "run"}

--- a/attestation/configuration/configuration_test.go
+++ b/attestation/configuration/configuration_test.go
@@ -1,0 +1,304 @@
+// Copyright 2025 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configuration
+
+import (
+	"crypto"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestName(t *testing.T) {
+	attestor := New()
+	assert.Equal(t, "configuration", attestor.Name())
+}
+
+func TestType(t *testing.T) {
+	attestor := New()
+	assert.Equal(t, "https://witness.dev/attestations/configuration/v0.1", attestor.Type())
+}
+
+func TestRunType(t *testing.T) {
+	attestor := New()
+	assert.Equal(t, attestation.PreMaterialRunType, attestor.RunType())
+}
+
+func TestAttest_BasicFlagCapture(t *testing.T) {
+	attestor := New(WithCustomArgs(func() []string {
+		return []string{"witness", "run", "-a", "configuration", "--step", "build", "-o", "output.json"}
+	}))
+	a := New()
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{a})
+	require.NoError(t, err)
+	err = attestor.Attest(ctx)
+	require.NoError(t, err)
+	err = ctx.RunAttestors()
+	require.NoError(t, err)
+
+	assert.Equal(t, "configuration", attestor.Flags["a"])
+	assert.Equal(t, "build", attestor.Flags["step"])
+	assert.Equal(t, "output.json", attestor.Flags["o"])
+}
+
+func TestAttest_MixedFlagFormats(t *testing.T) {
+	attestor := New(WithCustomArgs(func() []string {
+		return []string{
+			"witness", "run",
+			"-a", "configuration",
+			"--step=build",
+			"--trace",
+			"-o", "output.json",
+		}
+	}))
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	require.NoError(t, err)
+	err = attestor.Attest(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, "configuration", attestor.Flags["a"])
+	assert.Equal(t, "build", attestor.Flags["step"])
+	assert.Equal(t, "true", attestor.Flags["trace"])
+	assert.Equal(t, "output.json", attestor.Flags["o"])
+}
+
+func TestAttest_FlagsWithCommandSeparator(t *testing.T) {
+	attestor := New(WithCustomArgs(func() []string {
+		return []string{
+			"witness", "run",
+			"-a", "configuration",
+			"--step", "build",
+			"--",
+			"go", "build", ".",
+		}
+	}))
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	require.NoError(t, err)
+	err = attestor.Attest(ctx)
+	require.NoError(t, err)
+
+	// Should only capture witness flags, not command after --
+	assert.Equal(t, "configuration", attestor.Flags["a"])
+	assert.Equal(t, "build", attestor.Flags["step"])
+	assert.Len(t, attestor.Flags, 2)
+}
+
+func TestAttest_CustomConfigPathLongFlag(t *testing.T) {
+	attestor := New(WithCustomArgs(func() []string {
+		return []string{"witness", "run", "--config", "custom.yaml"}
+	}))
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	require.NoError(t, err)
+	err = attestor.Attest(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom.yaml", attestor.ConfigPath)
+}
+
+func TestExtractWitnessArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected []string
+	}{
+		{
+			name:     "no separator",
+			args:     []string{"witness", "run", "-a", "configuration"},
+			expected: []string{"witness", "run", "-a", "configuration"},
+		},
+		{
+			name:     "with separator",
+			args:     []string{"witness", "run", "-a", "configuration", "--", "go", "build", "."},
+			expected: []string{"witness", "run", "-a", "configuration"},
+		},
+		{
+			name:     "separator at end",
+			args:     []string{"witness", "run", "--"},
+			expected: []string{"witness", "run"},
+		},
+		{
+			name:     "empty args",
+			args:     []string{},
+			expected: []string{},
+		},
+		{
+			name:     "only command after separator",
+			args:     []string{"witness", "run", "--", "bash", "-c", "echo hi"},
+			expected: []string{"witness", "run"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractWitnessArgs(tt.args)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      []string
+		expected map[string]string
+	}{
+		{
+			name:     "empty command",
+			cmd:      []string{"witness"},
+			expected: map[string]string{},
+		},
+		{
+			name: "single long flag with space",
+			cmd:  []string{"witness", "--step", "build"},
+			expected: map[string]string{
+				"step": "build",
+			},
+		},
+		{
+			name: "single short flag",
+			cmd:  []string{"witness", "-a", "configuration"},
+			expected: map[string]string{
+				"a": "configuration",
+			},
+		},
+		{
+			name: "flag with equals",
+			cmd:  []string{"witness", "--step=build"},
+			expected: map[string]string{
+				"step": "build",
+			},
+		},
+		{
+			name: "short flag with equals",
+			cmd:  []string{"witness", "-o=output.json"},
+			expected: map[string]string{
+				"o": "output.json",
+			},
+		},
+		{
+			name: "boolean flag",
+			cmd:  []string{"witness", "--trace"},
+			expected: map[string]string{
+				"trace": "true",
+			},
+		},
+		{
+			name: "multiple flags mixed",
+			cmd:  []string{"witness", "-a", "configuration", "--step", "build", "--trace"},
+			expected: map[string]string{
+				"a":     "configuration",
+				"step":  "build",
+				"trace": "true",
+			},
+		},
+		{
+			name: "flags with special characters",
+			cmd:  []string{"witness", "--rekor-server", "https://rekor.sigstore.dev"},
+			expected: map[string]string{
+				"rekor-server": "https://rekor.sigstore.dev",
+			},
+		},
+		{
+			name: "flags with paths",
+			cmd:  []string{"witness", "--key", "/path/to/key.pem", "-o", "./output.json"},
+			expected: map[string]string{
+				"key": "/path/to/key.pem",
+				"o":   "./output.json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseFlags(tt.cmd)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestConfigDigest_ValidYAML(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, ".witness.yaml")
+
+	configContent := `run:
+  signer-file-key-path: testkey.pem
+  trace: false
+verify:
+  attestations:
+    - "test-att.json"
+  policy: policy-signed.json
+  publickey: testpub.pem
+`
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	oldWd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(oldWd)
+
+	err = os.Chdir(tempDir)
+	require.NoError(t, err)
+
+	attestor := New(WithCustomArgs(func() []string {
+		return []string{"witness", "run"}
+	}))
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	require.NoError(t, err)
+	err = attestor.Attest(ctx)
+	require.NoError(t, err)
+
+	// Verify digest is calculated
+	assert.NotNil(t, attestor.ConfigDigest)
+	assert.NotEmpty(t, attestor.ConfigDigest)
+
+	// Verify SHA256 digest exists
+	digestValue, exists := attestor.ConfigDigest[cryptoutil.DigestValue{
+		Hash:    crypto.SHA256,
+		GitOID:  false,
+		DirHash: false,
+	}]
+	assert.True(t, exists, "SHA256 digest should exist")
+	assert.NotEmpty(t, digestValue)
+	assert.Len(t, digestValue, 64, "SHA256 should be 64 hex characters")
+
+	// Verify content is parsed
+	assert.NotNil(t, attestor.ConfigContent)
+
+	// Verify run section
+	runConfig, ok := attestor.ConfigContent["run"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "testkey.pem", runConfig["signer-file-key-path"])
+	assert.Equal(t, false, runConfig["trace"])
+
+	// Verify verify section
+	verifyConfig, ok := attestor.ConfigContent["verify"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "policy-signed.json", verifyConfig["policy"])
+	assert.Equal(t, "testpub.pem", verifyConfig["publickey"])
+
+	attestations, ok := verifyConfig["attestations"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, attestations, 1)
+	assert.Equal(t, "test-att.json", attestations[0])
+}

--- a/attestation/configuration/configuration_test.go
+++ b/attestation/configuration/configuration_test.go
@@ -115,6 +115,24 @@ func TestAttest_CustomConfigPathLongFlag(t *testing.T) {
 	assert.Equal(t, "custom.yaml", attestor.ConfigPath)
 }
 
+func TestAttest_NoConfigFlag(t *testing.T) {
+	// When no --config/-c flag is provided, ConfigPath must stay empty
+	// so callers can distinguish "no config used" from a loaded file.
+	// Witness no longer defaults to .witness.yaml.
+	attestor := New(WithCustomArgs(func() []string {
+		return []string{"witness", "run", "-a", "configuration", "--step", "build"}
+	}))
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	require.NoError(t, err)
+	err = attestor.Attest(ctx)
+	require.NoError(t, err)
+
+	assert.Empty(t, attestor.ConfigPath)
+	assert.Empty(t, attestor.ConfigDigest)
+	assert.Empty(t, attestor.ConfigContent)
+}
+
 func TestExtractWitnessArgs(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -238,7 +256,7 @@ func TestParseFlags(t *testing.T) {
 
 func TestConfigDigest_ValidYAML(t *testing.T) {
 	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".witness.yaml")
+	configPath := filepath.Join(tempDir, "witness.yaml")
 
 	configContent := `run:
   signer-file-key-path: testkey.pem
@@ -252,12 +270,8 @@ verify:
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
-	oldDir, _ := os.Getwd()
-	require.NoError(t, os.Chdir(tempDir))
-	t.Cleanup(func() { _ = os.Chdir(oldDir) })
-
 	attestor := New(WithCustomArgs(func() []string {
-		return []string{"witness", "run"}
+		return []string{"witness", "run", "--config", configPath}
 	}))
 
 	ctx, err := attestation.NewContext("test", []attestation.Attestor{})

--- a/attestation/configuration/configuration_test.go
+++ b/attestation/configuration/configuration_test.go
@@ -21,7 +21,9 @@ import (
 	"testing"
 
 	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/attestation/product"
 	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,220 +43,66 @@ func TestRunType(t *testing.T) {
 	assert.Equal(t, attestation.PreMaterialRunType, attestor.RunType())
 }
 
-func TestAttest_BasicFlagCapture(t *testing.T) {
-	attestor := New(WithCustomArgs(func() []string {
-		return []string{"witness", "run", "-a", "configuration", "--step", "build", "-o", "output.json"}
-	}))
-	a := New()
-	ctx, err := attestation.NewContext("test", []attestation.Attestor{a})
-	require.NoError(t, err)
-	err = attestor.Attest(ctx)
-	require.NoError(t, err)
-	err = ctx.RunAttestors()
-	require.NoError(t, err)
+func TestAttest_CommandLineRecordedVerbatim(t *testing.T) {
+	args := []string{"witness", "run", "-a", "git", "-a", "slsa", "--step", "build", "--", "go", "build", "."}
+	attestor := New(WithCommandLine(args))
 
-	assert.Equal(t, "configuration", attestor.Flags["a"])
-	assert.Equal(t, "build", attestor.Flags["step"])
-	assert.Equal(t, "output.json", attestor.Flags["o"])
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
+	require.NoError(t, err)
+	require.NoError(t, attestor.Attest(ctx))
+
+	assert.Equal(t, args, attestor.CommandLine)
 }
 
-func TestAttest_MixedFlagFormats(t *testing.T) {
-	attestor := New(WithCustomArgs(func() []string {
-		return []string{
-			"witness", "run",
-			"-a", "configuration",
-			"--step=build",
-			"--trace",
-			"-o", "output.json",
-		}
-	}))
+func TestAttest_NoCommandLineByDefault(t *testing.T) {
+	attestor := New()
 
-	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
 	require.NoError(t, err)
-	err = attestor.Attest(ctx)
-	require.NoError(t, err)
+	require.NoError(t, attestor.Attest(ctx))
 
-	assert.Equal(t, "configuration", attestor.Flags["a"])
-	assert.Equal(t, "build", attestor.Flags["step"])
-	assert.Equal(t, "true", attestor.Flags["trace"])
-	assert.Equal(t, "output.json", attestor.Flags["o"])
+	assert.Empty(t, attestor.CommandLine)
 }
 
-func TestAttest_FlagsWithCommandSeparator(t *testing.T) {
-	attestor := New(WithCustomArgs(func() []string {
-		return []string{
-			"witness", "run",
-			"-a", "configuration",
-			"--step", "build",
-			"--",
-			"go", "build", ".",
-		}
-	}))
+func TestAttest_ResolvedConfig(t *testing.T) {
+	resolved := map[string]ResolvedValue{
+		"step":                 {Value: "build", Source: "commandline"},
+		"attestors":            {Value: []string{"git", "slsa"}, Source: "commandline"},
+		"trace":                {Value: "false", Source: "default"},
+		"signer-file-key-path": {Value: "testkey.pem", Source: "config"},
+	}
+	attestor := New(WithResolvedConfig(resolved))
 
-	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
 	require.NoError(t, err)
-	err = attestor.Attest(ctx)
-	require.NoError(t, err)
+	require.NoError(t, attestor.Attest(ctx))
 
-	// Should only capture witness flags, not command after --
-	assert.Equal(t, "configuration", attestor.Flags["a"])
-	assert.Equal(t, "build", attestor.Flags["step"])
-	assert.Len(t, attestor.Flags, 2)
+	assert.Equal(t, resolved, attestor.Resolved)
 }
 
-func TestAttest_CustomConfigPathLongFlag(t *testing.T) {
-	attestor := New(WithCustomArgs(func() []string {
-		return []string{"witness", "run", "--config", "custom.yaml"}
-	}))
+func TestAttest_NoConfigFile(t *testing.T) {
+	// ConfigPath stays empty so callers can distinguish "no config used"
+	// from a loaded file. Witness no longer defaults to .witness.yaml.
+	attestor := New()
 
-	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
 	require.NoError(t, err)
-	err = attestor.Attest(ctx)
-	require.NoError(t, err)
-
-	assert.Equal(t, "custom.yaml", attestor.ConfigPath)
-}
-
-func TestAttest_NoConfigFlag(t *testing.T) {
-	// When no --config/-c flag is provided, ConfigPath must stay empty
-	// so callers can distinguish "no config used" from a loaded file.
-	// Witness no longer defaults to .witness.yaml.
-	attestor := New(WithCustomArgs(func() []string {
-		return []string{"witness", "run", "-a", "configuration", "--step", "build"}
-	}))
-
-	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
-	require.NoError(t, err)
-	err = attestor.Attest(ctx)
-	require.NoError(t, err)
+	require.NoError(t, attestor.Attest(ctx))
 
 	assert.Empty(t, attestor.ConfigPath)
 	assert.Empty(t, attestor.ConfigDigest)
 	assert.Empty(t, attestor.ConfigContent)
 }
 
-func TestExtractWitnessArgs(t *testing.T) {
-	tests := []struct {
-		name     string
-		args     []string
-		expected []string
-	}{
-		{
-			name:     "no separator",
-			args:     []string{"witness", "run", "-a", "configuration"},
-			expected: []string{"witness", "run", "-a", "configuration"},
-		},
-		{
-			name:     "with separator",
-			args:     []string{"witness", "run", "-a", "configuration", "--", "go", "build", "."},
-			expected: []string{"witness", "run", "-a", "configuration"},
-		},
-		{
-			name:     "separator at end",
-			args:     []string{"witness", "run", "--"},
-			expected: []string{"witness", "run"},
-		},
-		{
-			name:     "empty args",
-			args:     []string{},
-			expected: []string{},
-		},
-		{
-			name:     "only command after separator",
-			args:     []string{"witness", "run", "--", "bash", "-c", "echo hi"},
-			expected: []string{"witness", "run"},
-		},
-	}
+func TestAttest_MissingConfigFileErrors(t *testing.T) {
+	attestor := New(WithConfigFile("does-not-exist.yaml"))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := extractWitnessArgs(tt.args)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
+	require.NoError(t, err)
+	assert.Error(t, attestor.Attest(ctx))
 }
 
-func TestParseFlags(t *testing.T) {
-	tests := []struct {
-		name     string
-		cmd      []string
-		expected map[string]string
-	}{
-		{
-			name:     "empty command",
-			cmd:      []string{"witness"},
-			expected: map[string]string{},
-		},
-		{
-			name: "single long flag with space",
-			cmd:  []string{"witness", "--step", "build"},
-			expected: map[string]string{
-				"step": "build",
-			},
-		},
-		{
-			name: "single short flag",
-			cmd:  []string{"witness", "-a", "configuration"},
-			expected: map[string]string{
-				"a": "configuration",
-			},
-		},
-		{
-			name: "flag with equals",
-			cmd:  []string{"witness", "--step=build"},
-			expected: map[string]string{
-				"step": "build",
-			},
-		},
-		{
-			name: "short flag with equals",
-			cmd:  []string{"witness", "-o=output.json"},
-			expected: map[string]string{
-				"o": "output.json",
-			},
-		},
-		{
-			name: "boolean flag",
-			cmd:  []string{"witness", "--trace"},
-			expected: map[string]string{
-				"trace": "true",
-			},
-		},
-		{
-			name: "multiple flags mixed",
-			cmd:  []string{"witness", "-a", "configuration", "--step", "build", "--trace"},
-			expected: map[string]string{
-				"a":     "configuration",
-				"step":  "build",
-				"trace": "true",
-			},
-		},
-		{
-			name: "flags with special characters",
-			cmd:  []string{"witness", "--rekor-server", "https://rekor.sigstore.dev"},
-			expected: map[string]string{
-				"rekor-server": "https://rekor.sigstore.dev",
-			},
-		},
-		{
-			name: "flags with paths",
-			cmd:  []string{"witness", "--key", "/path/to/key.pem", "-o", "./output.json"},
-			expected: map[string]string{
-				"key": "/path/to/key.pem",
-				"o":   "./output.json",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := parseFlags(tt.cmd)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestConfigDigest_ValidYAML(t *testing.T) {
+func TestAttest_ConfigFileDigestAndContent(t *testing.T) {
 	tempDir := t.TempDir()
 	configPath := filepath.Join(tempDir, "witness.yaml")
 
@@ -267,49 +115,80 @@ verify:
   policy: policy-signed.json
   publickey: testpub.pem
 `
-	err := os.WriteFile(configPath, []byte(configContent), 0644)
-	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
 
-	attestor := New(WithCustomArgs(func() []string {
-		return []string{"witness", "run", "--config", configPath}
-	}))
+	attestor := New(WithConfigFile(configPath))
 
-	ctx, err := attestation.NewContext("test", []attestation.Attestor{})
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor})
 	require.NoError(t, err)
-	err = attestor.Attest(ctx)
-	require.NoError(t, err)
+	require.NoError(t, attestor.Attest(ctx))
 
-	// Verify digest is calculated
-	assert.NotNil(t, attestor.ConfigDigest)
+	assert.Equal(t, configPath, attestor.ConfigPath)
 	assert.NotEmpty(t, attestor.ConfigDigest)
 
-	// Verify SHA256 digest exists
 	digestValue, exists := attestor.ConfigDigest[cryptoutil.DigestValue{
 		Hash:    crypto.SHA256,
 		GitOID:  false,
 		DirHash: false,
 	}]
 	assert.True(t, exists, "SHA256 digest should exist")
-	assert.NotEmpty(t, digestValue)
 	assert.Len(t, digestValue, 64, "SHA256 should be 64 hex characters")
 
-	// Verify content is parsed
-	assert.NotNil(t, attestor.ConfigContent)
-
-	// Verify run section
-	runConfig, ok := attestor.ConfigContent["run"].(map[string]interface{})
+	runConfig, ok := attestor.ConfigContent["run"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "testkey.pem", runConfig["signer-file-key-path"])
 	assert.Equal(t, false, runConfig["trace"])
 
-	// Verify verify section
-	verifyConfig, ok := attestor.ConfigContent["verify"].(map[string]interface{})
+	verifyConfig, ok := attestor.ConfigContent["verify"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "policy-signed.json", verifyConfig["policy"])
 	assert.Equal(t, "testpub.pem", verifyConfig["publickey"])
 
-	attestations, ok := verifyConfig["attestations"].([]interface{})
+	attestations, ok := verifyConfig["attestations"].([]any)
 	require.True(t, ok)
 	assert.Len(t, attestations, 1)
 	assert.Equal(t, "test-att.json", attestations[0])
+}
+
+type fakeConfigurableAttestor struct {
+	config map[string]any
+}
+
+func (f *fakeConfigurableAttestor) Name() string { return "fake" }
+func (f *fakeConfigurableAttestor) Type() string { return "https://witness.dev/attestations/fake/v0.1" }
+func (f *fakeConfigurableAttestor) RunType() attestation.RunType {
+	return attestation.PostProductRunType
+}
+func (f *fakeConfigurableAttestor) Schema() *jsonschema.Schema { return &jsonschema.Schema{} }
+func (f *fakeConfigurableAttestor) Attest(ctx *attestation.AttestationContext) error {
+	return nil
+}
+func (f *fakeConfigurableAttestor) Configuration() map[string]any { return f.config }
+
+func TestAttest_CollectsAttestorConfigurations(t *testing.T) {
+	fake := &fakeConfigurableAttestor{config: map[string]any{"fake-option": 42}}
+	prod := product.New(product.WithIncludeGlob("*.tar.gz"))
+	attestor := New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor, fake, prod})
+	require.NoError(t, err)
+	require.NoError(t, attestor.Attest(ctx))
+
+	require.Contains(t, attestor.Attestors, "fake")
+	assert.Equal(t, map[string]any{"fake-option": 42}, attestor.Attestors["fake"])
+
+	require.Contains(t, attestor.Attestors, "product")
+	assert.Equal(t, "*.tar.gz", attestor.Attestors["product"]["include-glob"])
+
+	assert.NotContains(t, attestor.Attestors, "configuration")
+}
+
+func TestAttest_WorkingDir(t *testing.T) {
+	attestor := New()
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{attestor}, attestation.WithWorkingDir("/some/dir"))
+	require.NoError(t, err)
+	require.NoError(t, attestor.Attest(ctx))
+
+	assert.Equal(t, "/some/dir", attestor.WorkingDir)
 }

--- a/attestation/context.go
+++ b/attestation/context.go
@@ -292,6 +292,13 @@ func (ctx *AttestationContext) CompletedAttestors() []CompletedAttestor {
 	return out
 }
 
+// Attestors returns the attestors that are part of this run.
+func (ctx *AttestationContext) Attestors() []Attestor {
+	out := make([]Attestor, len(ctx.attestors))
+	copy(out, ctx.attestors)
+	return out
+}
+
 func (ctx *AttestationContext) WorkingDir() string {
 	return ctx.workingDir
 }

--- a/attestation/factory.go
+++ b/attestation/factory.go
@@ -75,6 +75,13 @@ type MultiExporter interface {
 	ExportedAttestations() []Attestor
 }
 
+// Configurer allows attestors to expose their effective configuration so the
+// configuration attestor can record it. Implementations must only return config
+// set before the run started, never data gathered during Attest.
+type Configurer interface {
+	Configuration() map[string]any
+}
+
 // BackReffer allows attestors to indicate which of their subjects are good candidates
 // to find related attestations.  For example the git attestor's commit hash subject
 // is a good candidate to find all attestation collections that also refer to a specific

--- a/attestation/product/product.go
+++ b/attestation/product/product.go
@@ -43,9 +43,10 @@ const (
 // This is a hacky way to create a compile time error in case the attestor
 // doesn't implement the expected interfaces.
 var (
-	_ attestation.Attestor  = &Attestor{}
-	_ attestation.Subjecter = &Attestor{}
-	_ attestation.Producer  = &Attestor{}
+	_ attestation.Attestor   = &Attestor{}
+	_ attestation.Subjecter  = &Attestor{}
+	_ attestation.Producer   = &Attestor{}
+	_ attestation.Configurer = &Attestor{}
 )
 
 type ProductAttestor interface {
@@ -167,6 +168,13 @@ func New(opts ...Option) *Attestor {
 	}
 
 	return a
+}
+
+func (a *Attestor) Configuration() map[string]any {
+	return map[string]any{
+		"include-glob": a.includeGlob,
+		"exclude-glob": a.excludeGlob,
+	}
 }
 
 func (a *Attestor) Schema() *jsonschema.Schema {

--- a/imports.go
+++ b/imports.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/in-toto/go-witness/attestation/aws-codebuild"
 	_ "github.com/in-toto/go-witness/attestation/aws-iid"
 	_ "github.com/in-toto/go-witness/attestation/commandrun"
+	_ "github.com/in-toto/go-witness/attestation/configuration"
 	_ "github.com/in-toto/go-witness/attestation/docker"
 	_ "github.com/in-toto/go-witness/attestation/environment"
 	_ "github.com/in-toto/go-witness/attestation/gcp-iit"

--- a/schemagen/configuration.json
+++ b/schemagen/configuration.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/Attestor",
+  "$defs": {
+    "Attestor": {
+      "properties": {
+        "flags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "config_path": {
+          "type": "string"
+        },
+        "config_digest": {
+          "type": "string"
+        },
+        "working_directory": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/schemagen/configuration.json
+++ b/schemagen/configuration.json
@@ -14,13 +14,22 @@
           "type": "string"
         },
         "config_digest": {
-          "type": "string"
+          "$ref": "#/$defs/DigestSet"
+        },
+        "config_content": {
+          "type": "object"
         },
         "working_directory": {
           "type": "string"
         }
       },
       "additionalProperties": false,
+      "type": "object"
+    },
+    "DigestSet": {
+      "additionalProperties": {
+        "type": "string"
+      },
       "type": "object"
     }
   }

--- a/schemagen/configuration.json
+++ b/schemagen/configuration.json
@@ -4,9 +4,15 @@
   "$defs": {
     "Attestor": {
       "properties": {
-        "flags": {
-          "additionalProperties": {
+        "command_line": {
+          "items": {
             "type": "string"
+          },
+          "type": "array"
+        },
+        "resolved": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ResolvedValue"
           },
           "type": "object"
         },
@@ -17,6 +23,12 @@
           "$ref": "#/$defs/DigestSet"
         },
         "config_content": {
+          "type": "object"
+        },
+        "attestors": {
+          "additionalProperties": {
+            "type": "object"
+          },
           "type": "object"
         },
         "working_directory": {
@@ -31,6 +43,19 @@
         "type": "string"
       },
       "type": "object"
+    },
+    "ResolvedValue": {
+      "properties": {
+        "value": true,
+        "source": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "value"
+      ]
     }
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it

Description
A configuration attestor captures the configuration that governed a witness run: the raw command line, the fully-resolved configuration (flags + config file merged), the config file itself (path, digest, content), and the effective post-parse configuration of each attestor.

Updated Examples -
Running on Mac -

```yaml
// test.yaml

swf (main) $ cat test.yaml
run:
    trace: false
    attestor-product-exclude-glob: "*.att.json"
```

```ts
$ witness-dev run --step build -c test.yaml --signer-file-key-path testkey.pem -o build.att.json -a configuration --attestor-product-exclude-glob "*.log" -- go build -o testapp .

{
  "type": "https://witness.dev/attestations/configuration/v0.1",
  "attestation": {
    "command_line": [
      "witness-dev", "run", "--step", "build", "-c", "test.yaml",
      "--signer-file-key-path", "testkey.pem", "-o", "build.att.json",
      "-a", "configuration", "--attestor-product-exclude-glob", "*.log",
      "--", "go", "build", "-o", "testapp", "."
    ],
    "resolved": {
      "step":                          { "value": "build", "source": "commandline" },
      "attestations":                  { "value": ["configuration"], "source": "commandline" },
      "signer-file-key-path":          { "value": "testkey.pem", "source": "commandline" },
      "attestor-product-exclude-glob": { "value": "*.log", "source": "commandline" },
      "trace":                         { "value": "false", "source": "commandline" },
      "attestor-product-include-glob": { "value": "*", "source": "default" }
      // ... every flag of the run command, each tagged with its source
    },
    "config_path": "test.yaml",
    "config_digest": {
      "sha256": "6a884b5955ecf35d8f03f79be55d4247d33730711b96fef0470ec2e17dd2f05f"
    },
    "config_content": {
      "run": {
        "attestor-product-exclude-glob": "*.att.json",
        "trace": false
      }
    },
    "attestors": {
      "product": {
        "exclude-glob": "*.log",
        "include-glob": "*"
      }
    },
    "working_directory": "/Users/rahulxf/JourneyToXYZ/hello-world-witness"
  },
  "starttime": "2026-08-07T00:26:51.784235+05:30",
  "endtime": "2026-08-07T00:26:51.78437+05:30"
}
```

Note in the example above: the config file set exclude-glob: "*.att.json" but the CLI overrode it with "*.log". config_content records what the file claimed while attestors.product records what actually ran, so a policy can detect when a build was not governed by the config file it carried.

Library usage (no CLI) works without any injection. command_line and resolved stay empty and attestor configs are still collected via the Configurer interface.

Fixes #414

### todo:
- [x] Unit tests of the new attestor
- [ ] Follow-up PR in in-toto/witness to inject CLI config (small change in cmd/run.go, tested locally end to end)
- [ ] More attestors implementing Configurer (incremental)

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
