### PR TITLE
feat: Add configurable search paths for lockfiles attestor

### DIFF
--- a/attestation/lockfiles/lockfiles.go
+++ b/attestation/lockfiles/lockfiles.go
@@ -44,14 +44,17 @@ func init() {
 }
 
 func NewLockfilesAttestor() attestation.Attestor {
+	searchPaths := os.Getenv("WITNESS_LOCKFILES_SEARCH_PATHS")
 	return &Attestor{
-		Lockfiles: []LockfileInfo{},
+		Lockfiles:   []LockfileInfo{},
+		SearchPaths: searchPaths,
 	}
 }
 
 // Attestor implements the lockfiles attestation type
 type Attestor struct {
-	Lockfiles []LockfileInfo `json:"lockfiles"`
+	Lockfiles   []LockfileInfo `json:"lockfiles"`
+	SearchPaths string         `json:"-"` // Configuration field, not included in attestation
 }
 
 // LockfileInfo stores information about a lockfile
@@ -80,41 +83,137 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		"Podfile.lock",      // iOS/macOS (CocoaPods)
 		"gradle.lockfile",   // Gradle
 		"pnpm-lock.yaml",    // Node.js (pnpm)
+		"requirements.txt",  // Python (pip)
 	}
 
 	a.Lockfiles = []LockfileInfo{}
 
-	for _, pattern := range lockfilePatterns {
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			return fmt.Errorf("error searching for %s: %w", pattern, err)
+	// Determine search directories
+	searchDirs := []string{"."}
+	if a.SearchPaths != "" {
+		if a.SearchPaths == "recursive" {
+			// Recursively search from current directory
+			return a.searchRecursive(".", lockfilePatterns)
 		}
+		// Parse comma-separated list of directories
+		searchDirs = parseSearchPaths(a.SearchPaths)
+	}
 
-		for _, match := range matches {
-			content, err := os.ReadFile(match)
-			if err != nil {
-				return fmt.Errorf("error reading %s: %w", match, err)
-			}
-
-			// Define required digest algorithms
-			requiredDigestValues := []cryptoutil.DigestValue{
-				{Hash: crypto.SHA256},
-			}
-
-			// Compute the digest of the lockfile content
-			digest, err := cryptoutil.CalculateDigestSetFromBytes(content, requiredDigestValues)
-			if err != nil {
-				return fmt.Errorf("error computing digest of %s: %w", match, err)
-			}
-
-			a.Lockfiles = append(a.Lockfiles, LockfileInfo{
-				Filename: filepath.Base(match),
-				Content:  string(content),
-				Digest:   digest,
-			})
+	// Search in specified directories
+	for _, dir := range searchDirs {
+		if err := a.searchInDirectory(dir, lockfilePatterns); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+// parseSearchPaths splits a comma-separated list of paths and trims whitespace
+func parseSearchPaths(paths string) []string {
+	var result []string
+	for _, p := range filepath.SplitList(paths) {
+		trimmed := filepath.Clean(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// searchInDirectory searches for lockfiles in a specific directory
+func (a *Attestor) searchInDirectory(dir string, patterns []string) error {
+	for _, pattern := range patterns {
+		searchPattern := filepath.Join(dir, pattern)
+		matches, err := filepath.Glob(searchPattern)
+		if err != nil {
+			return fmt.Errorf("error searching for %s: %w", searchPattern, err)
+		}
+
+		for _, match := range matches {
+			if err := a.addLockfile(match); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// searchRecursive recursively searches for lockfiles from a root directory
+func (a *Attestor) searchRecursive(root string, patterns []string) error {
+	// Default directories to ignore
+	defaultIgnore := map[string]bool{
+		"node_modules": true,
+		"vendor":       true,
+		".git":         true,
+		".svn":         true,
+		".hg":          true,
+		"__pycache__":  true,
+		"venv":         true,
+		".venv":        true,
+		"target":       true, // Rust/Java build output
+		"build":        true,
+		"dist":         true,
+	}
+
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip ignored directories
+		if info.IsDir() && path != root {
+			dirName := info.Name()
+			// Skip hidden directories
+			if len(dirName) > 0 && dirName[0] == '.' {
+				return filepath.SkipDir
+			}
+			// Skip default ignore directories
+			if defaultIgnore[dirName] {
+				return filepath.SkipDir
+			}
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Check if file matches any lockfile pattern
+		for _, pattern := range patterns {
+			if matched, _ := filepath.Match(pattern, info.Name()); matched {
+				if err := a.addLockfile(path); err != nil {
+					return err
+				}
+				break
+			}
+		}
+		return nil
+	})
+}
+
+// addLockfile reads a lockfile and adds it to the attestation
+func (a *Attestor) addLockfile(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading %s: %w", path, err)
+	}
+
+	// Define required digest algorithms
+	requiredDigestValues := []cryptoutil.DigestValue{
+		{Hash: crypto.SHA256},
+	}
+
+	// Compute the digest of the lockfile content
+	digest, err := cryptoutil.CalculateDigestSetFromBytes(content, requiredDigestValues)
+	if err != nil {
+		return fmt.Errorf("error computing digest of %s: %w", path, err)
+	}
+
+	a.Lockfiles = append(a.Lockfiles, LockfileInfo{
+		Filename: path,
+		Content:  string(content),
+		Digest:   digest,
+	})
 	return nil
 }
 

--- a/attestation/lockfiles/lockfiles_test.go
+++ b/attestation/lockfiles/lockfiles_test.go
@@ -17,6 +17,7 @@ package lockfiles
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/in-toto/go-witness/attestation"
@@ -95,5 +96,290 @@ func TestAttestor_Name(t *testing.T) {
 	attestor := &Attestor{}
 	if name := attestor.Name(); name != "lockfiles" {
 		t.Errorf("Incorrect attestor name. Got %s, want lockfiles", name)
+	}
+}
+
+func TestAttestor_Attest_SpecificDirectories(t *testing.T) {
+	// Create temporary directory structure
+	tempDir, err := os.MkdirTemp("", "lockfiles_test_dirs")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create subdirectories
+	nodeDir := filepath.Join(tempDir, "node-app")
+	pythonDir := filepath.Join(tempDir, "python-app")
+	if err := os.MkdirAll(nodeDir, 0755); err != nil {
+		t.Fatalf("Failed to create node-app dir: %v", err)
+	}
+	if err := os.MkdirAll(pythonDir, 0755); err != nil {
+		t.Fatalf("Failed to create python-app dir: %v", err)
+	}
+
+	// Create lockfiles in subdirectories
+	nodeContent := "node lockfile content"
+	pythonContent := "python lockfile content"
+	if err := os.WriteFile(filepath.Join(nodeDir, "package-lock.json"), []byte(nodeContent), 0644); err != nil {
+		t.Fatalf("Failed to create package-lock.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pythonDir, "requirements.txt"), []byte(pythonContent), 0644); err != nil {
+		t.Fatalf("Failed to create requirements.txt: %v", err)
+	}
+
+	// Change to temp directory
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Errorf("Failed to change back to original directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Create attestor with specific directories
+	attestor := &Attestor{
+		SearchPaths: "node-app" + string(os.PathListSeparator) + "python-app",
+	}
+	ctx := &attestation.AttestationContext{}
+
+	// Run the Attest method
+	err = attestor.Attest(ctx)
+	if err != nil {
+		t.Fatalf("Attest failed: %v", err)
+	}
+
+	// Check if both lockfiles were found
+	if len(attestor.Lockfiles) != 2 {
+		t.Errorf("Expected 2 lockfiles, but got %d", len(attestor.Lockfiles))
+	}
+
+	// Verify content
+	foundNode := false
+	foundPython := false
+	for _, lockfile := range attestor.Lockfiles {
+		if filepath.Base(lockfile.Filename) == "package-lock.json" {
+			if lockfile.Content != nodeContent {
+				t.Errorf("package-lock.json content mismatch")
+			}
+			foundNode = true
+		}
+		if filepath.Base(lockfile.Filename) == "requirements.txt" {
+			if lockfile.Content != pythonContent {
+				t.Errorf("requirements.txt content mismatch")
+			}
+			foundPython = true
+		}
+	}
+
+	if !foundNode {
+		t.Error("package-lock.json not found in attestation")
+	}
+	if !foundPython {
+		t.Error("requirements.txt not found in attestation")
+	}
+}
+
+func TestAttestor_Attest_RecursiveSearch(t *testing.T) {
+	// Create temporary directory structure
+	tempDir, err := os.MkdirTemp("", "lockfiles_test_recursive")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create nested directory structure
+	subDir1 := filepath.Join(tempDir, "app1")
+	subDir2 := filepath.Join(tempDir, "app2", "nested")
+	if err := os.MkdirAll(subDir1, 0755); err != nil {
+		t.Fatalf("Failed to create app1 dir: %v", err)
+	}
+	if err := os.MkdirAll(subDir2, 0755); err != nil {
+		t.Fatalf("Failed to create app2/nested dir: %v", err)
+	}
+
+	// Create lockfiles at different levels (using absolute paths for creation)
+	testFilesAbs := map[string]string{
+		filepath.Join(tempDir, "package-lock.json"):      "root lockfile",
+		filepath.Join(subDir1, "Gemfile.lock"):           "app1 lockfile",
+		filepath.Join(subDir2, "requirements.txt"):       "nested lockfile",
+	}
+
+	// Expected relative paths in attestation
+	testFiles := map[string]string{
+		"package-lock.json":             "root lockfile",
+		"app1/Gemfile.lock":            "app1 lockfile",
+		"app2/nested/requirements.txt": "nested lockfile",
+	}
+
+	for path, content := range testFilesAbs {
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create %s: %v", path, err)
+		}
+	}
+
+	// Create a .git directory to test skipping hidden dirs
+	gitDir := filepath.Join(tempDir, ".git")
+	if err := os.MkdirAll(gitDir, 0755); err != nil {
+		t.Fatalf("Failed to create .git dir: %v", err)
+	}
+	// This file should be skipped
+	if err := os.WriteFile(filepath.Join(gitDir, "package-lock.json"), []byte("should be ignored"), 0644); err != nil {
+		t.Fatalf("Failed to create .git/package-lock.json: %v", err)
+	}
+
+	// Change to temp directory
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Errorf("Failed to change back to original directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Create attestor with recursive search
+	attestor := &Attestor{
+		SearchPaths: "recursive",
+	}
+	ctx := &attestation.AttestationContext{}
+
+	// Run the Attest method
+	err = attestor.Attest(ctx)
+	if err != nil {
+		t.Fatalf("Attest failed: %v", err)
+	}
+
+	// Check if all lockfiles were found (excluding .git)
+	if len(attestor.Lockfiles) != 3 {
+		t.Errorf("Expected 3 lockfiles, but got %d", len(attestor.Lockfiles))
+		for _, lf := range attestor.Lockfiles {
+			t.Logf("Found: %s", lf.Filename)
+		}
+	}
+
+	// Verify .git directory was skipped
+	for _, lockfile := range attestor.Lockfiles {
+		if strings.Contains(lockfile.Filename, ".git") {
+			t.Errorf("Lockfile from .git directory should have been skipped: %s", lockfile.Filename)
+		}
+	}
+
+	// Verify content
+	foundFiles := make(map[string]bool)
+	for _, lockfile := range attestor.Lockfiles {
+		expectedContent, ok := testFiles[lockfile.Filename]
+		if !ok {
+			t.Errorf("Unexpected lockfile found: %s", lockfile.Filename)
+			continue
+		}
+		if lockfile.Content != expectedContent {
+			t.Errorf("Content mismatch for %s", lockfile.Filename)
+		}
+		foundFiles[lockfile.Filename] = true
+	}
+
+	// Verify all expected files were found
+	for path := range testFiles {
+		if !foundFiles[path] {
+			t.Errorf("Expected lockfile not found: %s", path)
+		}
+	}
+}
+
+func TestAttestor_Attest_RecursiveSearch_IgnoreDirectories(t *testing.T) {
+	// Create temporary directory structure
+	tempDir, err := os.MkdirTemp("", "lockfiles_test_ignore")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create directories including ones that should be ignored
+	appDir := filepath.Join(tempDir, "app")
+	nodeModulesDir := filepath.Join(tempDir, "node_modules")
+	vendorDir := filepath.Join(tempDir, "vendor")
+
+	for _, dir := range []string{appDir, nodeModulesDir, vendorDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create dir %s: %v", dir, err)
+		}
+	}
+
+	// Create lockfiles in various directories
+	validLockfile := filepath.Join(appDir, "package-lock.json")
+	ignoredLockfile1 := filepath.Join(nodeModulesDir, "package-lock.json")
+	ignoredLockfile2 := filepath.Join(vendorDir, "Gemfile.lock")
+
+	if err := os.WriteFile(validLockfile, []byte("valid lockfile"), 0644); err != nil {
+		t.Fatalf("Failed to create valid lockfile: %v", err)
+	}
+	if err := os.WriteFile(ignoredLockfile1, []byte("should be ignored"), 0644); err != nil {
+		t.Fatalf("Failed to create ignored lockfile 1: %v", err)
+	}
+	if err := os.WriteFile(ignoredLockfile2, []byte("should be ignored"), 0644); err != nil {
+		t.Fatalf("Failed to create ignored lockfile 2: %v", err)
+	}
+
+	// Change to temp directory
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Errorf("Failed to change back to original directory: %v", err)
+		}
+	}()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Create attestor with recursive search
+	attestor := &Attestor{
+		SearchPaths: "recursive",
+	}
+	ctx := &attestation.AttestationContext{}
+
+	// Run the Attest method
+	err = attestor.Attest(ctx)
+	if err != nil {
+		t.Fatalf("Attest failed: %v", err)
+	}
+
+	// Should only find 1 lockfile (the one in app/)
+	if len(attestor.Lockfiles) != 1 {
+		t.Errorf("Expected 1 lockfile, but got %d", len(attestor.Lockfiles))
+		for _, lf := range attestor.Lockfiles {
+			t.Logf("Found: %s", lf.Filename)
+		}
+	}
+
+	// Verify node_modules and vendor were skipped
+	for _, lockfile := range attestor.Lockfiles {
+		if strings.Contains(lockfile.Filename, "node_modules") {
+			t.Errorf("Lockfile from node_modules should have been skipped: %s", lockfile.Filename)
+		}
+		if strings.Contains(lockfile.Filename, "vendor") {
+			t.Errorf("Lockfile from vendor should have been skipped: %s", lockfile.Filename)
+		}
+	}
+
+	// Verify the valid lockfile was found
+	if len(attestor.Lockfiles) == 1 {
+		if !strings.Contains(attestor.Lockfiles[0].Filename, "app/package-lock.json") {
+			t.Errorf("Expected lockfile from app/ but got: %s", attestor.Lockfiles[0].Filename)
+		}
+		if attestor.Lockfiles[0].Content != "valid lockfile" {
+			t.Errorf("Content mismatch for valid lockfile")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds configurable search paths for the lockfiles attestor, addressing the limitation where it could only find lock files in the current working directory. This is particularly useful for monorepo structures where lock files are located in subdirectories.

## Changes

### Core Functionality
- **Environment Variable**: Added `WITNESS_LOCKFILES_SEARCH_PATHS` to configure search behavior
- **Three Modes**:
  1. Unset/empty: Current directory only (backward compatible with existing behavior)
  2. `"recursive"`: Recursively search from current directory
  3. Comma-separated paths: Search specific directories (e.g., `"node-app:python-app"`)

### Enhancements
- Added default ignore list for common directories to prevent capturing lock files from dependencies:
  - `node_modules`, `vendor`, `.git`, `.svn`, `.hg`
  - `__pycache__`, `venv`, `.venv`
  - `target`, `build`, `dist`
- Added `requirements.txt` to default lockfile patterns for Python pip
- Now stores full path in `Filename` field (previously only basename) to provide better context when searching multiple directories

### Breaking Changes
- **Minor**: `Filename` field now contains the full relative path instead of just the basename
  - Previous: `"package-lock.json"`
  - New: `"node-app/package-lock.json"` (when searching subdirectories)
  - This provides better context and doesn't break functionality, just changes the data format slightly

## Usage Examples

### Recursive Search
\`\`\`bash
export WITNESS_LOCKFILES_SEARCH_PATHS="recursive"
witness run --attestations lockfiles ...
\`\`\`

### Specific Directories
\`\`\`bash
export WITNESS_LOCKFILES_SEARCH_PATHS="node-app:python-app:frontend"
witness run --attestations lockfiles ...
\`\`\`

### Default Behavior (Backward Compatible)
\`\`\`bash
# No environment variable set - searches current directory only
witness run --attestations lockfiles ...
\`\`\`

## Testing

Added comprehensive tests covering:
- ✅ Specific directory search
- ✅ Recursive search
- ✅ Default ignore directories (node_modules, vendor)
- ✅ Hidden directory skipping (.git)
- ✅ Backward compatibility (existing test still passes)

All tests pass:
\`\`\`
=== RUN   TestAttestor_Attest
--- PASS: TestAttestor_Attest (0.00s)
=== RUN   TestAttestor_Name
--- PASS: TestAttestor_Name (0.00s)
=== RUN   TestAttestor_Attest_SpecificDirectories
--- PASS: TestAttestor_Attest_SpecificDirectories (0.00s)
=== RUN   TestAttestor_Attest_RecursiveSearch
--- PASS: TestAttestor_Attest_RecursiveSearch (0.00s)
=== RUN   TestAttestor_Attest_RecursiveSearch_IgnoreDirectories
--- PASS: TestAttestor_Attest_RecursiveSearch_IgnoreDirectories (0.00s)
PASS
ok      github.com/in-toto/go-witness/attestation/lockfiles     0.418s
\`\`\`

## Use Case

This solves a common problem in monorepo setups:

**Before**: Lockfiles attestor could only find lock files in the repo root, missing lock files in subdirectories.

**After**: Can specify which subdirectories to search, or recursively search the entire tree while ignoring dependency directories.

## Related

Fixes issue where lockfiles attestor returns empty results in monorepo structures with lock files in subdirectories.