### PR TITLE
Implement `PreExec`, `PreExit` hooks in `commandrun`

### DIFF
--- a/attestation/commandrun/tracing_unsupported.go
+++ b/attestation/commandrun/tracing_unsupported.go
@@ -26,6 +26,10 @@ import (
 func enableTracing(c *exec.Cmd) {
 }
 
-func (rc *CommandRun) trace(c *exec.Cmd, actx *attestation.AttestationContext) ([]ProcessInfo, error) {
+func (rc *CommandRun) trace(c *exec.Cmd, actx *attestation.AttestationContext, hasPreExec, hasPreExit bool) ([]ProcessInfo, error) {
 	return nil, errors.New("tracing not supported on this platform")
+}
+
+func (rc *CommandRun) runWithHooks(c *exec.Cmd, hasPreExec, hasPreExit bool) error {
+	return errors.New("tracing not supported on this platform")
 }


### PR DESCRIPTION
## What this PR does / why we need it

This PR implement the `PreExec`, `PreExit` hooks proposed in https://github.com/in-toto/go-witness/pull/627 for the `commandrun` attestor. It relies on `ptrace` for implementing these hooks. 

## Which issue(s) this PR fixes (optional)

Part of adding `networktrace` attestor : https://github.com/in-toto/witness/issues/36

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:

Ignore the first commit, review only the second commit. First commit is https://github.com/in-toto/go-witness/pull/627