### PR TITLE
fix: handle cosign encrypted keys with empty passphrase

### DIFF
--- a/cryptoutil/util.go
+++ b/cryptoutil/util.go
@@ -134,12 +134,12 @@ func TryParsePEMBlockWithPassword(block *pem.Block, password []byte) (interface{
 		return nil, ErrInvalidPemBlock{}
 	}
 
-	if isSigstorePEMType(block.Type) && len(password) == 0 {
+	if isSigstorePEMType(block.Type) && password == nil {
 		return nil, fmt.Errorf("encrypted sigstore private key requires a non-empty passphrase (use --key-passphrase, --key-passphrase-path, or WITNESS_KEY_PASSPHRASE)")
 	}
 
 	// If no password, only attempt unencrypted formats and return.
-	if len(password) == 0 {
+	if password == nil {
 		// Unencrypted formats.
 		if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
 			return key, nil
@@ -234,7 +234,18 @@ func TryParseKeyFromReaderWithPassword(r io.Reader, password []byte) (interface{
 		return nil, err
 	}
 
-	if len(password) == 0 {
+	if pemBlock, _ := pem.Decode(bytes); pemBlock != nil && password != nil {
+		switch pemBlock.Type {
+		case "ENCRYPTED SIGSTORE PRIVATE KEY", "ENCRYPTED COSIGN PRIVATE KEY":
+			key, err := pemutil.ParseCosignPrivateKey(pemBlock.Bytes, password)
+			if err != nil {
+				return nil, err
+			}
+			return key, nil
+		}
+	}
+
+	if password == nil {
 		// We may want to handle files with multiple PEM blocks in them, but for now...
 		pemBlock, _ := pem.Decode(bytes)
 		return TryParsePEMBlockWithPassword(pemBlock, password)
@@ -246,7 +257,15 @@ func TryParseKeyFromReaderWithPassword(r io.Reader, password []byte) (interface{
 
 	// Use smallstep's pemutil to parse and decrypt various PEM/DER key formats,
 	// including PKCS#8 EncryptedPrivateKeyInfo.
-	obj, err := pemutil.Parse(bytes, pemutil.WithPassword(password))
+	var opts []pemutil.Options
+	if len(password) == 0 {
+		opts = append(opts, pemutil.WithPasswordPrompt("", func(string) ([]byte, error) {
+			return []byte{}, nil
+		}))
+	} else {
+		opts = append(opts, pemutil.WithPassword(password))
+	}
+	obj, err := pemutil.Parse(bytes, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

handle ENCRYPTED COSIGN PRIVATE KEY the same as sigstore encrypted keys
- add tests for empty-passphrase cosign keys (nil/empty byte slice)

## Testing
- go test ./go-witness/cryptoutil -run CosignEmptyPassphrase

This normalizes behavior with how cosign itself handles encrypted keys.