### PR TITLE
feat: support offline KMS verification with embedded public keys

### DIFF
--- a/cmd/verify-test/main.go
+++ b/cmd/verify-test/main.go
@@ -1,0 +1,156 @@
+// verify-test is a simple command-line tool to test offline KMS verification
+// using the embedded public key feature
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/dsse"
+	"github.com/in-toto/go-witness/policy"
+	"github.com/in-toto/go-witness/signer"
+
+	// Import AWS KMS provider
+	_ "github.com/in-toto/go-witness/signer/kms/aws"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <policy.json> <attestation.json>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	policyPath := os.Args[1]
+	attestationPath := os.Args[2]
+
+	// Read the policy file
+	policyData, err := os.ReadFile(policyPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read policy file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Check if it's a signed policy (DSSE envelope)
+	var policyEnvelope dsse.Envelope
+	if err := json.Unmarshal(policyData, &policyEnvelope); err == nil && policyEnvelope.PayloadType != "" {
+		// It's a DSSE envelope - the Payload is already decoded from base64 by json.Unmarshal
+		// because it's a []byte field
+		policyData = policyEnvelope.Payload
+		fmt.Println("Decoded signed policy envelope")
+	}
+
+	// Parse the policy
+	var pol policy.Policy
+	if err := json.Unmarshal(policyData, &pol); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse policy: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Policy loaded successfully\n")
+	fmt.Printf("  - Steps: %d\n", len(pol.Steps))
+	fmt.Printf("  - Public Keys: %d\n", len(pol.PublicKeys))
+
+	// Print public key info
+	for keyID, pk := range pol.PublicKeys {
+		fmt.Printf("    - Key ID: %s\n", keyID)
+		fmt.Printf("      Has embedded key: %v (%d bytes)\n", len(pk.Key) > 0, len(pk.Key))
+	}
+
+	// Create verifiers from the policy's public keys
+	// This is the key test - it should work WITHOUT AWS credentials
+	fmt.Println("\n=== Testing PublicKeyVerifiers (the fix) ===")
+	fmt.Println("Creating verifiers from policy public keys...")
+	fmt.Println("(This should succeed without AWS KMS access when embedded keys are present)")
+	
+	verifiers, err := pol.PublicKeyVerifiers(map[string][]func(signer.SignerProvider) (signer.SignerProvider, error){})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n❌ Failed to create verifiers: %v\n", err)
+		fmt.Fprintf(os.Stderr, "\nThis error indicates the fix is NOT working.\n")
+		fmt.Fprintf(os.Stderr, "Expected: Verifiers created from embedded keys without KMS access.\n")
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n✅ Created %d verifiers successfully!\n", len(verifiers))
+	for keyID, v := range verifiers {
+		vKeyID, _ := v.KeyID()
+		fmt.Printf("  - Map Key (policy KeyID): %s\n", keyID)
+		fmt.Printf("    Verifier's computed KeyID: %s\n", vKeyID)
+	}
+
+	// Read the attestation file
+	attestationData, err := os.ReadFile(attestationPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read attestation file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse the attestation as a DSSE envelope
+	var attestationEnvelope dsse.Envelope
+	if err := json.Unmarshal(attestationData, &attestationEnvelope); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse attestation: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nAttestation loaded successfully\n")
+	fmt.Printf("  - Payload Type: %s\n", attestationEnvelope.PayloadType)
+	fmt.Printf("  - Signatures: %d\n", len(attestationEnvelope.Signatures))
+
+	for i, sig := range attestationEnvelope.Signatures {
+		fmt.Printf("    - Signature %d: KeyID=%s\n", i+1, sig.KeyID)
+	}
+
+	// Collect verifiers that match the signature key IDs
+	var matchingVerifiers []cryptoutil.Verifier
+	for _, sig := range attestationEnvelope.Signatures {
+		if verifier, ok := verifiers[sig.KeyID]; ok {
+			fmt.Printf("\n✅ Found matching verifier for signature key ID: %s\n", sig.KeyID)
+			matchingVerifiers = append(matchingVerifiers, verifier)
+		} else {
+			fmt.Printf("\n❌ No verifier found for signature key ID: %s\n", sig.KeyID)
+			// List available verifier key IDs
+			fmt.Println("Available verifier key IDs in map:")
+			for k := range verifiers {
+				fmt.Printf("  - %s\n", k)
+			}
+		}
+	}
+
+	if len(matchingVerifiers) == 0 {
+		fmt.Fprintf(os.Stderr, "\n❌ No matching verifiers found!\n")
+		fmt.Fprintf(os.Stderr, "This indicates the verifiers map is not keyed by the KMS URI.\n")
+		os.Exit(1)
+	}
+
+	// Verify the attestation signature using the DSSE envelope's Verify method
+	fmt.Println("\n=== Verifying attestation signature ===")
+	checkedVerifiers, err := attestationEnvelope.Verify(dsse.VerifyWithVerifiers(matchingVerifiers...))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "❌ Verification FAILED: %v\n", err)
+		
+		// Print details about checked verifiers
+		for _, cv := range checkedVerifiers {
+			keyID, _ := cv.Verifier.KeyID()
+			if cv.Error != nil {
+				fmt.Fprintf(os.Stderr, "  - Verifier %s: ERROR: %v\n", keyID, cv.Error)
+			} else {
+				fmt.Printf("  - Verifier %s: OK\n", keyID)
+			}
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n✅ Verification SUCCEEDED!\n")
+	fmt.Printf("Verified with %d verifier(s):\n", len(checkedVerifiers))
+	for _, cv := range checkedVerifiers {
+		keyID, _ := cv.Verifier.KeyID()
+		fmt.Printf("  - %s\n", keyID)
+	}
+	
+	fmt.Println("\n=== Summary ===")
+	fmt.Println("The KMS offline verification fix is working correctly!")
+	fmt.Println("- Embedded public key was used instead of contacting AWS KMS")
+	fmt.Println("- Verifier was stored under the KMS URI key ID for functionary matching")
+	fmt.Println("- Attestation signature was verified successfully")
+}

--- a/cmd/verify-test/main.go
+++ b/cmd/verify-test/main.go
@@ -1,3 +1,17 @@
+// Copyright [Year] The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // verify-test is a simple command-line tool to test offline KMS verification
 // using the embedded public key feature
 package main

--- a/cmd/verify-test/main.go
+++ b/cmd/verify-test/main.go
@@ -63,7 +63,7 @@ func main() {
 	fmt.Println("\n=== Testing PublicKeyVerifiers (the fix) ===")
 	fmt.Println("Creating verifiers from policy public keys...")
 	fmt.Println("(This should succeed without AWS KMS access when embedded keys are present)")
-	
+
 	verifiers, err := pol.PublicKeyVerifiers(map[string][]func(signer.SignerProvider) (signer.SignerProvider, error){})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "\n❌ Failed to create verifiers: %v\n", err)
@@ -128,7 +128,7 @@ func main() {
 	checkedVerifiers, err := attestationEnvelope.Verify(dsse.VerifyWithVerifiers(matchingVerifiers...))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "❌ Verification FAILED: %v\n", err)
-		
+
 		// Print details about checked verifiers
 		for _, cv := range checkedVerifiers {
 			keyID, _ := cv.Verifier.KeyID()
@@ -147,7 +147,7 @@ func main() {
 		keyID, _ := cv.Verifier.KeyID()
 		fmt.Printf("  - %s\n", keyID)
 	}
-	
+
 	fmt.Println("\n=== Summary ===")
 	fmt.Println("The KMS offline verification fix is working correctly!")
 	fmt.Println("- Embedded public key was used instead of contacting AWS KMS")

--- a/cmd/verify-test/main.go
+++ b/cmd/verify-test/main.go
@@ -1,4 +1,4 @@
-// Copyright [Year] The Witness Contributors
+// Copyright 2026 The Witness Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -87,32 +87,32 @@ func (p Policy) PublicKeyVerifiers(ko map[string][]func(signer.SignerProvider) (
 			}
 		} else {
 			// No embedded key - check if this is a KMS key ID and use KMS service
-			for _, prefix := range kms.SupportedProviders() {
-				if strings.HasPrefix(key.KeyID, prefix) {
-					ksp := kms.New(kms.WithRef(key.KeyID), kms.WithHash("SHA256"))
-					var vp signer.SignerProvider
-					for _, opt := range ksp.Options {
-						pn := opt.ProviderName()
-						for _, setter := range ko[pn] {
-							vp, err = setter(ksp)
-							if err != nil {
-								continue
-							}
+		for _, prefix := range kms.SupportedProviders() {
+			if strings.HasPrefix(key.KeyID, prefix) {
+				ksp := kms.New(kms.WithRef(key.KeyID), kms.WithHash("SHA256"))
+				var vp signer.SignerProvider
+				for _, opt := range ksp.Options {
+					pn := opt.ProviderName()
+					for _, setter := range ko[pn] {
+						vp, err = setter(ksp)
+						if err != nil {
+							continue
 						}
 					}
+				}
 
-					if vp != nil {
-						var ok bool
-						ksp, ok = vp.(*kms.KMSSignerProvider)
-						if !ok {
-							return nil, fmt.Errorf("provided verifier provider is not a KMS verifier provider")
-						}
+				if vp != nil {
+					var ok bool
+					ksp, ok = vp.(*kms.KMSSignerProvider)
+					if !ok {
+						return nil, fmt.Errorf("provided verifier provider is not a KMS verifier provider")
 					}
+				}
 
-					verifier, err = ksp.Verifier(context.TODO())
-					if err != nil {
-						return nil, fmt.Errorf("failed to create kms verifier: %w", err)
-					}
+				verifier, err = ksp.Verifier(context.TODO())
+				if err != nil {
+					return nil, fmt.Errorf("failed to create kms verifier: %w", err)
+				}
 					break
 				}
 			}
@@ -143,12 +143,12 @@ func (p Policy) PublicKeyVerifiers(ko map[string][]func(signer.SignerProvider) (
 		// 1. It's not a KMS key ID, OR
 		// 2. It's a KMS key ID without an embedded key (verifier came from KMS)
 		if !isKMSKeyID || len(key.Key) == 0 {
-			if keyID != key.KeyID {
-				return nil, ErrKeyIDMismatch{
-					Expected: key.KeyID,
-					Actual:   keyID,
-				}
+		if keyID != key.KeyID {
+			return nil, ErrKeyIDMismatch{
+				Expected: key.KeyID,
+				Actual:   keyID,
 			}
+		}
 		}
 
 		// For KMS key IDs with embedded keys, wrap the verifier to return the KMS URI as its KeyID.

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -55,48 +55,60 @@ type PublicKey struct {
 	Key   []byte `json:"key"`
 }
 
-// PublicKeyVerifiers returns verifiers for each of the policy's embedded public keys grouped by the key's ID
+// PublicKeyVerifiers returns verifiers for each of the policy's embedded public keys grouped by the key's ID.
+// When a public key entry has both a KMS-style KeyID (e.g., awskms://...) AND an embedded key in the Key field,
+// the embedded key is used directly for verification. This enables offline/air-gap verification scenarios
+// where the KMS service may not be accessible. If no embedded key is provided, the KMS service is contacted.
 func (p Policy) PublicKeyVerifiers(ko map[string][]func(signer.SignerProvider) (signer.SignerProvider, error)) (map[string]cryptoutil.Verifier, error) {
 	verifiers := make(map[string]cryptoutil.Verifier)
 	var err error
 
 	for _, key := range p.PublicKeys {
 		var verifier cryptoutil.Verifier
-		for _, prefix := range kms.SupportedProviders() {
-			if strings.HasPrefix(key.KeyID, prefix) {
-				ksp := kms.New(kms.WithRef(key.KeyID), kms.WithHash("SHA256"))
-				var vp signer.SignerProvider
-				for _, opt := range ksp.Options {
-					pn := opt.ProviderName()
-					for _, setter := range ko[pn] {
-						vp, err = setter(ksp)
-						if err != nil {
-							continue
+
+		// If an embedded key is provided, use it directly for verification.
+		// This enables offline/air-gap verification even for KMS-style key IDs.
+		if len(key.Key) > 0 {
+			verifier, err = cryptoutil.NewVerifierFromReader(bytes.NewReader(key.Key))
+			if err != nil {
+				return nil, fmt.Errorf("failed to create verifier from embedded key: %w", err)
+			}
+		} else {
+			// No embedded key - check if this is a KMS key ID and use KMS service
+			for _, prefix := range kms.SupportedProviders() {
+				if strings.HasPrefix(key.KeyID, prefix) {
+					ksp := kms.New(kms.WithRef(key.KeyID), kms.WithHash("SHA256"))
+					var vp signer.SignerProvider
+					for _, opt := range ksp.Options {
+						pn := opt.ProviderName()
+						for _, setter := range ko[pn] {
+							vp, err = setter(ksp)
+							if err != nil {
+								continue
+							}
 						}
 					}
-				}
 
-				if vp != nil {
-					var ok bool
-					ksp, ok = vp.(*kms.KMSSignerProvider)
-					if !ok {
-						return nil, fmt.Errorf("provided verifier provider is not a KMS verifier provider")
+					if vp != nil {
+						var ok bool
+						ksp, ok = vp.(*kms.KMSSignerProvider)
+						if !ok {
+							return nil, fmt.Errorf("provided verifier provider is not a KMS verifier provider")
+						}
 					}
-				}
 
-				verifier, err = ksp.Verifier(context.TODO())
-				if err != nil {
-					return nil, fmt.Errorf("failed to create kms verifier: %w", err)
+					verifier, err = ksp.Verifier(context.TODO())
+					if err != nil {
+						return nil, fmt.Errorf("failed to create kms verifier: %w", err)
+					}
+					break
 				}
-
 			}
 		}
 
+		// If still no verifier and no embedded key, this is an error
 		if verifier == nil {
-			verifier, err = cryptoutil.NewVerifierFromReader(bytes.NewReader(key.Key))
-			if err != nil {
-				return nil, err
-			}
+			return nil, fmt.Errorf("no embedded key provided for key ID %s and key ID is not a recognized KMS reference", key.KeyID)
 		}
 
 		keyID, err := verifier.KeyID()
@@ -104,14 +116,31 @@ func (p Policy) PublicKeyVerifiers(ko map[string][]func(signer.SignerProvider) (
 			return nil, err
 		}
 
-		if keyID != key.KeyID {
-			return nil, ErrKeyIDMismatch{
-				Expected: key.KeyID,
-				Actual:   keyID,
+		// For KMS key IDs with embedded keys, the computed keyID from the embedded key
+		// will be a hash of the public key, not the KMS URI. We need to allow this mismatch
+		// when an embedded key is provided with a KMS-style key ID.
+		isKMSKeyID := false
+		for _, prefix := range kms.SupportedProviders() {
+			if strings.HasPrefix(key.KeyID, prefix) {
+				isKMSKeyID = true
+				break
 			}
 		}
 
-		verifiers[keyID] = verifier
+		// Only check keyID match if:
+		// 1. It's not a KMS key ID, OR
+		// 2. It's a KMS key ID without an embedded key (verifier came from KMS)
+		if !isKMSKeyID || len(key.Key) == 0 {
+			if keyID != key.KeyID {
+				return nil, ErrKeyIDMismatch{
+					Expected: key.KeyID,
+					Actual:   keyID,
+				}
+			}
+		}
+
+		// Use the policy's key ID as the map key (this preserves the KMS URI for functionary matching)
+		verifiers[key.KeyID] = verifier
 	}
 
 	return verifiers, nil


### PR DESCRIPTION
## What this PR does / why we need it

This PR fixes a bug in `PublicKeyVerifiers()` that prevents offline/air-gapped verification of attestations signed with KMS keys, even when the policy contains an embedded public key.

### The Bug

In the current implementation at [policy/policy.go lines 96-105](https://github.com/in-toto/go-witness/blob/1453b041480a3878a93a324452e6e1bc6899ac02/policy/policy.go#L96-L105):

1. When KMS is not accessible, the code correctly falls back to using the embedded key
2. However, it then computes `keyID` from the verifier, which returns a hash of the public key (e.g., `31a05aa1c7a1eaa51630a0f5e99caf4a10ae981ea8d16a44370bf7267b0bc392`)
3. It compares this against `key.KeyID`, which is the KMS URI (e.g., `awskms:///26059292-db29-4f01-91d9-b43fc584049c`)
4. These will **never** match, so `ErrKeyIDMismatch` is returned even though the embedded key is valid

Additionally, even after fixing the above, **functionary matching fails** because:
- The policy's functionary expects `PublicKeyID` to match the KMS URI
- But the verifier's `KeyID()` method returns the hash of the embedded public key
- This causes `Functionary.Validate()` to fail with "no verifiers matched with allowed functionaries"

### The Fix

This PR introduces two key changes:

1. **Prioritizes embedded keys**: When a policy entry has an embedded key, use it directly without attempting KMS calls, and skip the keyID mismatch check for KMS+embedded key combinations

2. **`keyIDOverrideVerifier` wrapper**: When creating a verifier from an embedded key for a KMS-style key ID, wrap it with `keyIDOverrideVerifier` that overrides the `KeyID()` method to return the KMS URI instead of the public key hash. This ensures functionary matching works correctly.

### Use Cases Enabled

- Air-gapped environments where KMS services are not accessible
- Offline verification workflows
- Reducing latency by avoiding KMS API calls
- CI/CD pipelines that need to verify attestations without KMS credentials

### Backward Compatibility

This change is fully backward compatible:
- If no embedded key is provided, the existing KMS verification path is used
- The keyID mismatch check is only skipped when BOTH a KMS-style key ID AND an embedded key are present
- Regular (non-KMS) keys are not wrapped and retain their original `KeyID()` behavior

## Which issue(s) this PR fixes (optional)

Fixes #648

## Acceptance Criteria Met

- [x] Docs changes if needed (updated function documentation)
- [x] Testing changes if needed (added comprehensive unit tests for offline KMS verification)
- [x] All workflow checks passing (automatically enforced)
- [x] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:

The key changes are in `policy/policy.go`:
- `keyIDOverrideVerifier` struct: Wraps a verifier to override `KeyID()` for functionary matching
- Lines 69-88: Prioritize embedded key when present and wrap with `keyIDOverrideVerifier` for KMS keys
- Lines 119-140: Skip keyID mismatch check for KMS+embedded key combinations
- Line 143: Store verifier under the policy key ID (not the computed key ID)

New tests in `policy/policy_test.go`:
- `TestKMSOfflineVerification`: Tests the basic offline verification functionality
- `TestKMSOfflineVerificationWithFunctionaries`: Tests that functionary matching still works
- `TestKeyIDOverrideVerifier`: Tests that the verifier's `KeyID()` returns the KMS URI
- `TestKeyIDOverrideVerifierNotAppliedToNonKMS`: Tests that non-KMS keys are not wrapped

A test tool is also included in `cmd/verify-test/` that demonstrates the fix working with real policy and attestation files.