### PR TITLE
fix: adds string ptr config option for when we care about nil values

### DIFF
--- a/registry/option.go
+++ b/registry/option.go
@@ -26,7 +26,7 @@ type Configurer interface {
 }
 
 type Option interface {
-	int | string | []string | bool | time.Duration
+	int | string | []string | bool | time.Duration | *string
 }
 
 type ConfigOption[T any, TOption Option] struct {
@@ -99,6 +99,15 @@ func BoolConfigOption[T any](name, description string, defaultVal bool, setter f
 
 func DurationConfigOption[T any](name, description string, defaultVal time.Duration, setter func(T, time.Duration) (T, error)) *ConfigOption[T, time.Duration] {
 	return &ConfigOption[T, time.Duration]{
+		name:        name,
+		description: description,
+		defaultVal:  defaultVal,
+		setter:      setter,
+	}
+}
+
+func StringPtrConfigOption[T any](name, description string, defaultVal *string, setter func(T, *string) (T, error)) *ConfigOption[T, *string] {
+	return &ConfigOption[T, *string]{
 		name:        name,
 		description: description,
 		defaultVal:  defaultVal,

--- a/signer/file/file.go
+++ b/signer/file/file.go
@@ -42,11 +42,11 @@ func init() {
 				return ksp, nil
 			},
 		),
-		registry.StringConfigOption(
+		registry.StringPtrConfigOption(
 			"key-passphrase",
 			"Passphrase to decrypt the private key (prefer key-passphrase-path).",
-			"",
-			func(sp signer.SignerProvider, pass string) (signer.SignerProvider, error) {
+			nil,
+			func(sp signer.SignerProvider, pass *string) (signer.SignerProvider, error) {
 				ksp, ok := sp.(FileSignerProvider)
 				if !ok {
 					return ksp, fmt.Errorf("provided signer provider is not a file signer provider")
@@ -129,9 +129,9 @@ func WithIntermediatePaths(intermediatePaths []string) Option {
 	}
 }
 
-func WithKeyPassphrase(pass string) Option {
+func WithKeyPassphrase(pass *string) Option {
 	return func(fsp *FileSignerProvider) {
-		fsp.Passphrase = &pass
+		fsp.Passphrase = pass
 	}
 }
 

--- a/signer/file/file_empty_passphrase_test.go
+++ b/signer/file/file_empty_passphrase_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var emptyPass = ""
+
 // generateSigstoreKeyWithEmptyPassphrase creates a sigstore-encrypted key PEM
 // with an empty passphrase for testing purposes.
 func generateSigstoreKeyWithEmptyPassphrase(t *testing.T) []byte {
@@ -56,10 +58,10 @@ func TestFileSignerProvider_EmptyPassphrase_Explicit(t *testing.T) {
 	dir := t.TempDir()
 	keyPEM := generateSigstoreKeyWithEmptyPassphrase(t)
 	keyPath := filepath.Join(dir, "key.pem")
-	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
 
 	// Use explicit empty passphrase via WithKeyPassphrase("")
-	fsp := New(WithKeyPath(keyPath), WithKeyPassphrase(""))
+	fsp := New(WithKeyPath(keyPath), WithKeyPassphrase(&emptyPass))
 	s, err := fsp.Signer(context.Background())
 	require.NoError(t, err)
 
@@ -76,11 +78,11 @@ func TestFileSignerProvider_EmptyPassphrase_FromFile(t *testing.T) {
 	dir := t.TempDir()
 	keyPEM := generateSigstoreKeyWithEmptyPassphrase(t)
 	keyPath := filepath.Join(dir, "key.pem")
-	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
 
 	// Empty passphrase file (no content)
 	passPath := filepath.Join(dir, "pass.txt")
-	require.NoError(t, os.WriteFile(passPath, []byte(""), 0600))
+	require.NoError(t, os.WriteFile(passPath, []byte(""), 0o600))
 
 	fsp := New(WithKeyPath(keyPath), WithKeyPassphrasePath(passPath))
 	s, err := fsp.Signer(context.Background())
@@ -99,11 +101,11 @@ func TestFileSignerProvider_EmptyPassphrase_FromFileWithNewline(t *testing.T) {
 	dir := t.TempDir()
 	keyPEM := generateSigstoreKeyWithEmptyPassphrase(t)
 	keyPath := filepath.Join(dir, "key.pem")
-	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
 
 	// Empty passphrase file with trailing newline (common in editors)
 	passPath := filepath.Join(dir, "pass.txt")
-	require.NoError(t, os.WriteFile(passPath, []byte("\n"), 0600))
+	require.NoError(t, os.WriteFile(passPath, []byte("\n"), 0o600))
 
 	fsp := New(WithKeyPath(keyPath), WithKeyPassphrasePath(passPath))
 	s, err := fsp.Signer(context.Background())
@@ -122,7 +124,7 @@ func TestFileSignerProvider_EmptyPassphrase_FromEnv(t *testing.T) {
 	dir := t.TempDir()
 	keyPEM := generateSigstoreKeyWithEmptyPassphrase(t)
 	keyPath := filepath.Join(dir, "key.pem")
-	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
 
 	// Set environment variable to empty string
 	t.Setenv("WITNESS_KEY_PASSPHRASE", "")
@@ -144,13 +146,13 @@ func TestFileSignerProvider_EmptyPassphrase_ExplicitPrecedence(t *testing.T) {
 	dir := t.TempDir()
 	keyPEM := generateSigstoreKeyWithEmptyPassphrase(t)
 	keyPath := filepath.Join(dir, "key.pem")
-	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
 
 	// Set env to wrong passphrase - explicit empty should take precedence
 	t.Setenv("WITNESS_KEY_PASSPHRASE", "wrong-password")
 
 	// Explicit empty passphrase should override the env var
-	fsp := New(WithKeyPath(keyPath), WithKeyPassphrase(""))
+	fsp := New(WithKeyPath(keyPath), WithKeyPassphrase(&emptyPass))
 	s, err := fsp.Signer(context.Background())
 	require.NoError(t, err)
 
@@ -167,7 +169,7 @@ func TestFileSignerProvider_SigstoreKey_NoPassphrase_Error(t *testing.T) {
 	dir := t.TempDir()
 	keyPEM := generateSigstoreKeyWithEmptyPassphrase(t)
 	keyPath := filepath.Join(dir, "key.pem")
-	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
 
 	// No passphrase provided at all - should fail for encrypted sigstore key
 	fsp := New(WithKeyPath(keyPath))

--- a/signer/file/file_pkcs8_test.go
+++ b/signer/file/file_pkcs8_test.go
@@ -44,12 +44,12 @@ zRUMp83etY/en4xYDagth5IUz9IGNsqauXf11xcDIBy6twew6QY+oER8xKaimgQ3
 zfmC
 -----END ENCRYPTED PRIVATE KEY-----`
 
-const passphrase = "s3cret-pass"
+var passphrase = "s3cret-pass"
 
 func writeTemp(dir, name, data string, t *testing.T) string {
 	t.Helper()
 	p := filepath.Join(dir, name)
-	require.NoError(t, os.WriteFile(p, []byte(data), 0600))
+	require.NoError(t, os.WriteFile(p, []byte(data), 0o600))
 	return p
 }
 
@@ -139,7 +139,7 @@ func TestFileSignerProvider_PassphraseExplicit_Precedence(t *testing.T) {
 	t.Setenv("WITNESS_KEY_PASSPHRASE", "ALSO_WRONG")
 
 	// Explicit passphrase should take precedence over file and env
-	fsp := New(WithKeyPath(keyPath), WithKeyPassphrasePath(passPath), WithKeyPassphrase(passphrase))
+	fsp := New(WithKeyPath(keyPath), WithKeyPassphrasePath(passPath), WithKeyPassphrase(&passphrase))
 	s, err := fsp.Signer(context.Background())
 	require.NoError(t, err)
 	v, err := s.Verifier()
@@ -166,8 +166,9 @@ func TestFileSignerProvider_WrongPassphrase_Error(t *testing.T) {
 	_, err = fsp2.Signer(context.Background())
 	require.Error(t, err)
 
+	wrongPass := "WRONG3"
 	// And explicit wrong
-	fsp3 := New(WithKeyPath(keyPath), WithKeyPassphrase("WRONG3"))
+	fsp3 := New(WithKeyPath(keyPath), WithKeyPassphrase(&wrongPass))
 	_, err = fsp3.Signer(context.Background())
 	require.Error(t, err)
 }


### PR DESCRIPTION
The file signer uses a string pointer for passphrases. Empty pass phrases are valid, so the difference between nil and empty string is meaningful.

The current implementation uses a string option type with a default of an empty string. This causes signers to load incorrectly when they are not an encrypted signer.

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [ ] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
