### PR TITLE
Drop copy of non-freely licensed DCO from CONTRIBUTORS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,45 +16,7 @@ specification for commit messages.  Please read and familiarize yourself with th
 work to be brought upstream.
 
 We also ask that you sign-off your commits.  By signing off you agree to the
-[Developer Certificate of Origin](https://developercertificate.org):
-
-```
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-
-```
+[Developer Certificate of Origin](https://developercertificate.org).
 
 Each commit should be a meaningful body of work.  This typically means a pull request will consist of a singular commit
 but there are cases where multiple commits per pull request is warranted.  It is okay to make small multiple commits


### PR DESCRIPTION
Hi!  This is part of the Debian packaging review.  The DCO text is not freely licensed, which means we cannot include it in Debian.  While we could avoid shipping the CONTRIBUTORS file completely, I am hoping this small fix is acceptable to you, which would allow shipping go-witness unmodified in Debian.  Deviating from upstream source code is painful from a supply-chain auditing perspective, even if changes are minor.

```
Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.
```

Thanks,
Simon
