### PR TITLE
fix linux builds on unsupported arch tracing helpers

### DIFF
--- a/attestation/commandrun/tracing_linux.go
+++ b/attestation/commandrun/tracing_linux.go
@@ -441,8 +441,8 @@ func (ctx *ptraceContext) readSyscallReg(pid int, addr uintptr, n int) (string, 
 	data := make([]byte, n)
 	localIov := unix.Iovec{
 		Base: &data[0],
-		Len:  getNativeUint(n),
 	}
+	localIov.SetLen(n)
 
 	removeIov := unix.RemoteIovec{
 		Base: addr,

--- a/attestation/commandrun/tracing_linux_386.go
+++ b/attestation/commandrun/tracing_linux_386.go
@@ -34,7 +34,3 @@ func getSyscallArgs(regs unix.PtraceRegs) []uintptr {
 		uintptr(regs.Ebp),
 	}
 }
-
-func getNativeUint(n int) uint32 {
-	return uint32(n)
-}

--- a/attestation/commandrun/tracing_linux_amd64.go
+++ b/attestation/commandrun/tracing_linux_amd64.go
@@ -34,7 +34,3 @@ func getSyscallArgs(regs unix.PtraceRegs) []uintptr {
 		uintptr(regs.R9),
 	}
 }
-
-func getNativeUint(n int) uint64 {
-	return uint64(n)
-}

--- a/attestation/commandrun/tracing_linux_arm.go
+++ b/attestation/commandrun/tracing_linux_arm.go
@@ -35,7 +35,3 @@ func getSyscallArgs(regs unix.PtraceRegs) []uintptr {
 		uintptr(regs.Uregs[5]),
 	}
 }
-
-func getNativeUint(n int) uint32 {
-	return uint32(n)
-}

--- a/attestation/commandrun/tracing_linux_arm64.go
+++ b/attestation/commandrun/tracing_linux_arm64.go
@@ -34,7 +34,3 @@ func getSyscallArgs(regs unix.PtraceRegs) []uintptr {
 		uintptr(regs.Regs[5]),
 	}
 }
-
-func getNativeUint(n int) uint64 {
-	return uint64(n)
-}

--- a/attestation/commandrun/tracing_linux_unsupported_arch.go
+++ b/attestation/commandrun/tracing_linux_unsupported_arch.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux && !amd64 && !arm64 && !arm && !386
+
+package commandrun
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Fallback syscall register decoding for Linux architectures that do not yet
+// have architecture-specific ptrace register mappings.
+func getSyscallId(regs unix.PtraceRegs) int {
+	return -1
+}
+
+func getSyscallArgs(regs unix.PtraceRegs) []uintptr {
+	return nil
+}


### PR DESCRIPTION
## What this PR does / why we need it

Fixes Linux build failures on architectures that do not have architecture specific ptrace syscall helper implementations (for example `riscv64`, `s390x`, `ppc64le`) in `attestation/commandrun`.

Changes made:
- Add a Linux fallback helper file for unsupported arches:
  - `attestation/commandrun/tracing_linux_unsupported_arch.go`
  - provides fallback `getSyscallId` / `getSyscallArgs` so package compiles on all Linux arches.
- Remove architecture specific `getNativeUint` dependency by switching to `Iovec.SetLen()` in:
  - `attestation/commandrun/tracing_linux.go`

This keeps current behavior for supported arch-specific files (`amd64`, `arm64`, `arm`, `386`) while preventing compile time breakage on other Linux targets.

## Which issue(s) this PR fixes (optional)

Fixes #684

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
Validated with:
- `go test ./attestation/commandrun`
- `GOOS=linux GOARCH=riscv64 go test -c ./attestation/commandrun`
- `GOOS=linux GOARCH=s390x go test -c ./attestation/commandrun`
- `GOOS=linux GOARCH=ppc64le go test -c ./attestation/commandrun`

Fallback helpers intentionally avoid arch specific register decoding for now; this PR focuses on build portability and unblocking downstream packaging.
