### PR TITLE
fix: prevent archivista nil client panic during verify

### DIFF
--- a/archivista/client.go
+++ b/archivista/client.go
@@ -15,9 +15,15 @@
 package archivista
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/in-toto/archivista/pkg/api"
+)
+
+var (
+	ErrClientNotConfigured = errors.New("archivista client is not configured")
+	ErrURLNotConfigured    = errors.New("archivista URL is not configured")
 )
 
 type Client struct {
@@ -53,9 +59,22 @@ func New(url string, opts ...Option) *Client {
 
 func (c *Client) archivistaRequestOpts() []api.RequestOption {
 	opts := make([]api.RequestOption, 0)
-	if c.headers != nil {
-		opts = append(opts, api.WithHeaders(c.headers))
+	if c == nil || c.headers == nil {
+		return opts
 	}
 
+	opts = append(opts, api.WithHeaders(c.headers))
 	return opts
+}
+
+func (c *Client) validate() error {
+	if c == nil {
+		return ErrClientNotConfigured
+	}
+
+	if c.url == "" {
+		return ErrURLNotConfigured
+	}
+
+	return nil
 }

--- a/archivista/client_test.go
+++ b/archivista/client_test.go
@@ -1,0 +1,49 @@
+// Copyright 2022 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archivista
+
+import (
+	"context"
+	"testing"
+
+	"github.com/in-toto/go-witness/dsse"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientMethodsWithNilReceiver(t *testing.T) {
+	var c *Client
+
+	_, err := c.Download(context.Background(), "sha256:deadbeef")
+	require.ErrorIs(t, err, ErrClientNotConfigured)
+
+	_, err = c.SearchGitoids(context.Background(), SearchGitoidVariables{})
+	require.ErrorIs(t, err, ErrClientNotConfigured)
+
+	_, err = c.Store(context.Background(), dsse.Envelope{})
+	require.ErrorIs(t, err, ErrClientNotConfigured)
+}
+
+func TestClientMethodsWithMissingURL(t *testing.T) {
+	c := New("")
+
+	_, err := c.Download(context.Background(), "sha256:deadbeef")
+	require.ErrorIs(t, err, ErrURLNotConfigured)
+
+	_, err = c.SearchGitoids(context.Background(), SearchGitoidVariables{})
+	require.ErrorIs(t, err, ErrURLNotConfigured)
+
+	_, err = c.Store(context.Background(), dsse.Envelope{})
+	require.ErrorIs(t, err, ErrURLNotConfigured)
+}

--- a/archivista/client_test.go
+++ b/archivista/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Witness Contributors
+// Copyright 2026 The Witness Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/archivista/download.go
+++ b/archivista/download.go
@@ -22,5 +22,9 @@ import (
 )
 
 func (c *Client) Download(ctx context.Context, gitoid string) (dsse.Envelope, error) {
+	if err := c.validate(); err != nil {
+		return dsse.Envelope{}, err
+	}
+
 	return archivistaapi.Download(ctx, c.url, gitoid, c.archivistaRequestOpts()...)
 }

--- a/archivista/searchgitoids.go
+++ b/archivista/searchgitoids.go
@@ -38,6 +38,10 @@ type SearchGitoidVariables struct {
 }
 
 func (c *Client) SearchGitoids(ctx context.Context, vars SearchGitoidVariables) ([]string, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
 	const query = `query ($subjectDigests: [String!], $attestations: [String!], $collectionName: String!, $excludeGitoids: [String!]) {
   dsses(
     where: {

--- a/archivista/store.go
+++ b/archivista/store.go
@@ -22,6 +22,10 @@ import (
 )
 
 func (c *Client) Store(ctx context.Context, env dsse.Envelope) (string, error) {
+	if err := c.validate(); err != nil {
+		return "", err
+	}
+
 	resp, err := archivistaapi.Store(ctx, c.url, env, c.archivistaRequestOpts()...)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a nil pointer panic in `witness verify` when Archivista is not configured.

### Description
- Adds defensive validation in Archivista client methods:
  - `Download`
  - `SearchGitoids`
  - `Store`
- Returns explicit errors instead of panicking when:
  - client is nil
  - Archivista URL is missing
- Adds regression tests for nil receiver and missing URL behavior.

## Which issue(s) this PR fixes (optional)

Fixes #591

## Acceptance Criteria Met

- [x] Docs changes if needed (not needed for this fix)
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
- Root cause was nil dereference in Archivista client calls during verify flow.
- This PR intentionally converts panic paths into normal errors for graceful failure.
- Validation run locally:
  - `go test ./archivista ./source ./internal/policy ./attestation/policyverify`
