### PR TITLE
fix(signer/fulcio): resolve early gRPC server shutdown in tests

### DIFF
--- a/signer/fulcio/fulcio_test.go
+++ b/signer/fulcio/fulcio_test.go
@@ -62,11 +62,11 @@ func setupFulcioTestService(t *testing.T) (*dummyCAClientService, string) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 	service.client = client
-	
+
 	t.Cleanup(func() {
 		service.server.Stop()
 	})
-	
+
 	go func() {
 		if err := service.server.Serve(lis); err != nil {
 			t.Logf("failed to serve: %v", err)
@@ -226,7 +226,6 @@ func TestGetCert(t *testing.T) {
 func TestSigner(t *testing.T) {
 	// Setup dummy CA client service
 	_, url := setupFulcioTestService(t)
-	
 
 	ctx := context.Background()
 
@@ -436,11 +435,11 @@ func setupRetryFulcioTestService(t *testing.T, maxFailures int32) (*retryCAClien
 		t.Fatalf("failed to create client: %v", err)
 	}
 	service.client = client
-	
+
 	t.Cleanup(func() {
 		service.server.Stop()
 	})
-	
+
 	go func() {
 		if err := service.server.Serve(lis); err != nil {
 			t.Logf("failed to serve: %v", err)
@@ -455,7 +454,6 @@ func TestGetCertRetryLogic(t *testing.T) {
 	t.Run("successful retry after transient failure", func(t *testing.T) {
 		// Setup service that fails first 2 attempts, succeeds on 3rd
 		service, _ := setupRetryFulcioTestService(t, 2)
-		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)
@@ -476,7 +474,6 @@ func TestGetCertRetryLogic(t *testing.T) {
 	t.Run("max retries exceeded", func(t *testing.T) {
 		// Setup service that always fails
 		service, _ := setupRetryFulcioTestService(t, 5)
-		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)
@@ -491,7 +488,6 @@ func TestGetCertRetryLogic(t *testing.T) {
 
 	t.Run("invalid token format validation", func(t *testing.T) {
 		service, _ := setupFulcioTestService(t)
-		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)
@@ -509,7 +505,6 @@ func TestGetCertRetryLogic(t *testing.T) {
 
 	t.Run("token without required claims", func(t *testing.T) {
 		service, _ := setupFulcioTestService(t)
-		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)

--- a/signer/fulcio/fulcio_test.go
+++ b/signer/fulcio/fulcio_test.go
@@ -62,9 +62,14 @@ func setupFulcioTestService(t *testing.T) (*dummyCAClientService, string) {
 		t.Fatalf("failed to create client: %v", err)
 	}
 	service.client = client
+	
+	t.Cleanup(func() {
+		service.server.Stop()
+	})
+	
 	go func() {
 		if err := service.server.Serve(lis); err != nil {
-			log.Fatalf("failed to serve: %v", err)
+			t.Logf("failed to serve: %v", err)
 		}
 	}()
 	return service, fmt.Sprintf("localhost:%d", lis.Addr().(*net.TCPAddr).Port)
@@ -220,8 +225,8 @@ func TestGetCert(t *testing.T) {
 
 func TestSigner(t *testing.T) {
 	// Setup dummy CA client service
-	service, url := setupFulcioTestService(t)
-	defer service.server.Stop()
+	_, url := setupFulcioTestService(t)
+	
 
 	ctx := context.Background()
 
@@ -431,9 +436,14 @@ func setupRetryFulcioTestService(t *testing.T, maxFailures int32) (*retryCAClien
 		t.Fatalf("failed to create client: %v", err)
 	}
 	service.client = client
+	
+	t.Cleanup(func() {
+		service.server.Stop()
+	})
+	
 	go func() {
 		if err := service.server.Serve(lis); err != nil {
-			log.Fatalf("failed to serve: %v", err)
+			t.Logf("failed to serve: %v", err)
 		}
 	}()
 	return service, fmt.Sprintf("localhost:%d", lis.Addr().(*net.TCPAddr).Port)
@@ -445,7 +455,7 @@ func TestGetCertRetryLogic(t *testing.T) {
 	t.Run("successful retry after transient failure", func(t *testing.T) {
 		// Setup service that fails first 2 attempts, succeeds on 3rd
 		service, _ := setupRetryFulcioTestService(t, 2)
-		defer service.server.Stop()
+		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)
@@ -466,7 +476,7 @@ func TestGetCertRetryLogic(t *testing.T) {
 	t.Run("max retries exceeded", func(t *testing.T) {
 		// Setup service that always fails
 		service, _ := setupRetryFulcioTestService(t, 5)
-		defer service.server.Stop()
+		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)
@@ -481,7 +491,7 @@ func TestGetCertRetryLogic(t *testing.T) {
 
 	t.Run("invalid token format validation", func(t *testing.T) {
 		service, _ := setupFulcioTestService(t)
-		defer service.server.Stop()
+		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)
@@ -499,7 +509,7 @@ func TestGetCertRetryLogic(t *testing.T) {
 
 	t.Run("token without required claims", func(t *testing.T) {
 		service, _ := setupFulcioTestService(t)
-		defer service.server.Stop()
+		
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)
@@ -535,10 +545,12 @@ func TestGetCertNonRetryableErrors(t *testing.T) {
 
 		go func() {
 			if err := service.server.Serve(lis); err != nil {
-				log.Fatalf("failed to serve: %v", err)
+				t.Logf("failed to serve: %v", err)
 			}
 		}()
-		defer service.server.Stop()
+		t.Cleanup(func() {
+			service.server.Stop()
+		})
 
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		require.NoError(t, err)


### PR DESCRIPTION
## What this PR does / why we need it

This PR resolves the `TestGetCertRetryLogic` failures caused by the early shutdown of the mock gRPC server in the `signer/fulcio` test suite. 

It bounds the test server teardown correctly by using `t.Cleanup(func() { service.server.Stop() })` inside the `setupFulcioTestService` and `setupRetryFulcioTestService` initialization functions. It also replaces `log.Fatalf` with `t.Logf` within the `.Serve()` goroutine, which prevents the test binary from forcefully panicking when `service.server.Stop()` legitimately interrupts `Serve()`. Finally, it removes duplicate and unnecessary `defer service.server.Stop()` statements across test functions.


### Fixes #698

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:

The `go test -v ./signer/fulcio/...` tests now pass stably locally without the `grpc: the server has been stopped` error or any premature shutdown issues.
