### PR TITLE
Add support for marking attestors as experimental

### DIFF
--- a/attestation/factory.go
+++ b/attestation/factory.go
@@ -89,6 +89,13 @@ type ExecuteHookDeclarer interface {
 	DeclareHooks(hooks *ExecuteHooks) error
 }
 
+// Experimental allows attestors to indicate that they are experimental and should be hidden from
+// users by default. This is useful for attestors that are still in development and may have breaking
+// changes before they are stable.
+type Experimental interface {
+	IsExperimental() bool
+}
+
 type ErrAttestationNotFound string
 
 func (e ErrAttestationNotFound) Error() string {
@@ -178,4 +185,12 @@ func AttestorOptions(nameOrType string) []registry.Configurer {
 
 func RegistrationEntries() []registry.Entry[Attestor] {
 	return attestorRegistry.AllEntries()
+}
+
+func IsExperimental(attestor Attestor) bool {
+	if experimentalAttestor, ok := attestor.(Experimental); ok {
+		return experimentalAttestor.IsExperimental()
+	}
+
+	return false
 }


### PR DESCRIPTION
## What this PR does / why we need it

Needed to mark attestors as experimental (like network trace)

## Which issue(s) this PR fixes (optional)

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [ ] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
