### PR TITLE
Run all configurers for new KMS signer providers

### DIFF
--- a/signer/kms/aws/options_test.go
+++ b/signer/kms/aws/options_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/in-toto/go-witness/signer"
+	"github.com/in-toto/go-witness/signer/kms"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAWSClientOptionDefaults ensures the AWS client options default values are
+// applied when creating a new KMS signer provider.
+func TestAWSClientOptionDefaults(t *testing.T) {
+	sp, err := signer.NewSignerProvider("kms")
+	require.NoError(t, err)
+
+	ksp, ok := sp.(*kms.KMSSignerProvider)
+	require.True(t, ok)
+
+	coIface, ok := ksp.Options[providerName]
+	require.True(t, ok)
+
+	co, ok := coIface.(*awsClientOptions)
+	require.True(t, ok)
+
+	require.Equal(t, true, co.verifyRemotely)
+	require.Equal(t, false, co.insecureSkipVerify)
+}

--- a/signer/kms/aws/options_test.go
+++ b/signer/kms/aws/options_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package aws
 
 import (

--- a/signer/kms/hashivault/options_test.go
+++ b/signer/kms/hashivault/options_test.go
@@ -1,0 +1,44 @@
+// Copyright 2024 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hashivault
+
+import (
+	"testing"
+
+	"github.com/in-toto/go-witness/signer"
+	"github.com/in-toto/go-witness/signer/kms"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultClientOptions ensures the provider-specific client options expose
+// the expected defaults for the transit engine path and the kubernetes SA token path
+// when creating a new signer via NewSignerProvider.
+func TestDefaultClientOptions(t *testing.T) {
+	sp, err := signer.NewSignerProvider("kms")
+	require.NoError(t, err)
+
+	ksp, ok := sp.(*kms.KMSSignerProvider)
+	require.True(t, ok)
+
+	// providerName and clientOptions are package-local to hashivault
+	coIface, ok := ksp.Options[providerName]
+	require.True(t, ok)
+
+	co, ok := coIface.(*clientOptions)
+	require.True(t, ok)
+
+	require.Equal(t, defaultTransitSecretEnginePath, co.transitSecretEnginePath)
+	require.Equal(t, defaultKubernetesSATokenPath, co.kubernetesSaTokenPath)
+}

--- a/signer/kms/hashivault/options_test.go
+++ b/signer/kms/hashivault/options_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Witness Contributors
+// Copyright 2026 The Witness Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/signer/kms/signerprovider.go
+++ b/signer/kms/signerprovider.go
@@ -176,6 +176,29 @@ func New(opts ...Option) *KMSSignerProvider {
 		ksp.Options[opt.ProviderName()] = opt
 	}
 
+	// Apply provider-specific client option defaults onto the signer provider
+	// so that each provider's Init() configurers run and populate default
+	// values (for example, transit path and kubernetes SA token path).
+	var allConfigurers []registry.Configurer
+	for _, opt := range ksp.Options {
+		if opt == nil {
+			continue
+		}
+		allConfigurers = append(allConfigurers, opt.Init()...)
+	}
+
+	if len(allConfigurers) > 0 {
+		reg := registry.New[signer.SignerProvider]()
+		// ignore error — New should not fail; if defaults fail to apply,
+		// we still return the constructed provider (best-effort defaults).
+		spWithDefaults, err := reg.SetDefaultVals(&ksp, allConfigurers)
+		if err == nil {
+			if ksp2, ok := spWithDefaults.(*KMSSignerProvider); ok {
+				ksp = *ksp2
+			}
+		}
+	}
+
 	return &ksp
 }
 


### PR DESCRIPTION
## What this PR does / why we need it

Applies all configurers when instantiating a new signer provider.

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #731

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
