### PR TITLE
fix(ci): save attestations and upload to workflow run instead of sending to archivista

### DIFF
--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -13,97 +13,97 @@
 # limitations under the License.
 
 on:
-    workflow_call:
-        inputs:
-            pull_request:
-                required: true
-                type: boolean
-            artifact-download:
-                required: false
-                type: string
-            artifact-upload-name:
-                required: false
-                type: string
-            artifact-upload-path:
-                required: false
-                type: string
-            pre-command:
-                required: false
-                type: string
-            command:
-                required: true
-                type: string
-            step:
-                required: true
-                type: string
-            attestations:
-                required: true
-                type: string
+  workflow_call:
+    inputs:
+      pull_request:
+        required: true
+        type: boolean
+      artifact-download:
+        required: false
+        type: string
+      artifact-upload-name:
+        required: false
+        type: string
+      artifact-upload-path:
+        required: false
+        type: string
+      pre-command:
+        required: false
+        type: string
+      command:
+        required: true
+        type: string
+      step:
+        required: true
+        type: string
+      attestations:
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
-    witness:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            id-token: write
-        steps:
-          - name: Harden Runner
-            uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-            with:
-              egress-policy: audit
+  witness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
 
-          - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-          - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-            with:
-              go-version-file: "go.mod"
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
 
-          - if: ${{ inputs.artifact-download != '' }}
-            uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-            with:
-              name: ${{ inputs.artifact-download }}
-              path: /tmp
+      - if: ${{ inputs.artifact-download != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-download }}
+          path: /tmp
 
-          - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
-            uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
-            with:
-              step: pre-${{ inputs.step }}
-              attestations: ${{ inputs.attestations }}
-              version: 0.11.0
-              outfile: pre-${{ inputs.step }}-attestation.json
-              enable-archivista: false
-              witness-install-dir: /usr/local/bin
-              command: /bin/sh -c "${{ inputs.pre-command }}"
-          - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
-            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-            with:
-              name: pre-${{ inputs.step }}-attestation
-              path: pre-${{ inputs.step }}-attestation.json
-          - if: ${{ inputs.pre-command != '' && inputs.pull_request == true }}
-            run: ${{ inputs.pre-command }}
+      - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
+        uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
+        with:
+          step: pre-${{ inputs.step }}
+          attestations: ${{ inputs.attestations }}
+          version: 0.11.0
+          outfile: pre-${{ inputs.step }}-attestation.json
+          enable-archivista: false
+          witness-install-dir: /usr/local/bin
+          command: /bin/sh -c "${{ inputs.pre-command }}"
+      - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pre-${{ inputs.step }}-attestation
+          path: pre-${{ inputs.step }}-attestation.json
+      - if: ${{ inputs.pre-command != '' && inputs.pull_request == true }}
+        run: ${{ inputs.pre-command }}
 
-          - if: ${{ inputs.pull_request == false }}
-            uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
-            with:
-              step: ${{ inputs.step }}
-              attestations: ${{ inputs.attestations }}
-              version: 0.11.0
-              outfile: ${{ inputs.step }}-attestation.json
-              enable-archivista: false
-              witness-install-dir: /usr/local/bin
-              command: /bin/sh -c "${{ inputs.command }}"
-          - if: ${{ inputs.pull_request == false }}
-            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-            with:
-              name: ${{ inputs.step }}-attestation
-              path: ${{ inputs.step }}-attestation.json
-          - if: ${{ inputs.pull_request == true }}
-            run: ${{ inputs.command }}
+      - if: ${{ inputs.pull_request == false }}
+        uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
+        with:
+          step: ${{ inputs.step }}
+          attestations: ${{ inputs.attestations }}
+          version: 0.11.0
+          outfile: ${{ inputs.step }}-attestation.json
+          enable-archivista: false
+          witness-install-dir: /usr/local/bin
+          command: /bin/sh -c "${{ inputs.command }}"
+      - if: ${{ inputs.pull_request == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.step }}-attestation
+          path: ${{ inputs.step }}-attestation.json
+      - if: ${{ inputs.pull_request == true }}
+        run: ${{ inputs.command }}
 
-          - if: ${{ inputs.artifact-upload-path != '' && inputs.artifact-upload-name != ''}}
-            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-            with:
-              name: ${{ inputs.artifact-upload-name }}
-              path: ${{ inputs.artifact-upload-path }}
+      - if: ${{ inputs.artifact-upload-path != '' && inputs.artifact-upload-name != ''}}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact-upload-name }}
+          path: ${{ inputs.artifact-upload-path }}

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -74,7 +74,7 @@ jobs:
               version: 0.11.0
               outfile: pre-${{ inputs.step }}-attestation.json
               enable-archivista: false
-              witness-install-dir: /tmp/witness
+              witness-install-dir: /usr/local/bin
               command: /bin/sh -c "${{ inputs.pre-command }}"
           - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
             uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -92,7 +92,7 @@ jobs:
               version: 0.11.0
               outfile: ${{ inputs.step }}-attestation.json
               enable-archivista: false
-              witness-install-dir: /tmp/witness
+              witness-install-dir: /usr/local/bin
               command: /bin/sh -c "${{ inputs.command }}"
           - if: ${{ inputs.pull_request == false }}
             uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -55,8 +55,12 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 
@@ -82,7 +86,9 @@ jobs:
           name: pre-${{ inputs.step }}-attestation
           path: pre-${{ inputs.step }}-attestation.json
       - if: ${{ inputs.pre-command != '' && inputs.pull_request == true }}
-        run: ${{ inputs.pre-command }}
+        run: bash -c "${INPUTS_COMMAND}"
+        env:
+          INPUTS_PRE_COMMAND: ${{ inputs.pre-command }}
 
       - if: ${{ inputs.pull_request == false }}
         uses: testifysec/witness-run-action@7aa15e327829f1f2a523365c564c948d5dde69dd
@@ -100,7 +106,9 @@ jobs:
           name: ${{ inputs.step }}-attestation
           path: ${{ inputs.step }}-attestation.json
       - if: ${{ inputs.pull_request == true }}
-        run: ${{ inputs.command }}
+        run: bash -c "${INPUTS_COMMAND}"
+        env:
+          INPUTS_COMMAND: ${{ inputs.command }}
 
       - if: ${{ inputs.artifact-upload-path != '' && inputs.artifact-upload-name != ''}}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/witness.yml
+++ b/.github/workflows/witness.yml
@@ -71,8 +71,16 @@ jobs:
             with:
               step: pre-${{ inputs.step }}
               attestations: ${{ inputs.attestations }}
-              version: 0.9.1
+              version: 0.11.0
+              outfile: pre-${{ inputs.step }}-attestation.json
+              enable-archivista: false
+              witness-install-dir: /tmp/witness
               command: /bin/sh -c "${{ inputs.pre-command }}"
+          - if: ${{ inputs.pre-command != '' && inputs.pull_request == false }}
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+              name: pre-${{ inputs.step }}-attestation
+              path: pre-${{ inputs.step }}-attestation.json
           - if: ${{ inputs.pre-command != '' && inputs.pull_request == true }}
             run: ${{ inputs.pre-command }}
 
@@ -81,8 +89,16 @@ jobs:
             with:
               step: ${{ inputs.step }}
               attestations: ${{ inputs.attestations }}
-              version: 0.9.1
+              version: 0.11.0
+              outfile: ${{ inputs.step }}-attestation.json
+              enable-archivista: false
+              witness-install-dir: /tmp/witness
               command: /bin/sh -c "${{ inputs.command }}"
+          - if: ${{ inputs.pull_request == false }}
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+            with:
+              name: ${{ inputs.step }}-attestation
+              path: ${{ inputs.step }}-attestation.json
           - if: ${{ inputs.pull_request == true }}
             run: ${{ inputs.command }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/in-toto/go-witness
 
-go 1.26.1
+go 1.26.4
 
 require (
 	cloud.google.com/go/kms v1.31.0


### PR DESCRIPTION
## What this PR does / why we need it

save attestations and upload to workflow run instead of sending to archivista. we can reenable archivista once a new public instance is available.