### PR TITLE
OCI: detect and parse spec compliant index.json

### DIFF
--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -24,12 +24,14 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/in-toto/go-witness/attestation"
 	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/in-toto/go-witness/log"
 	"github.com/invopop/jsonschema"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (
@@ -148,7 +150,7 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		return err
 	}
 
-	if err := a.parseMaifest(ctx); err != nil {
+	if err := a.parseManifest(ctx); err != nil {
 		log.Debugf("(attestation/oci) error parsing manifest: %w", err)
 		return err
 	}
@@ -200,14 +202,18 @@ func (a *Attestor) getCandidate(ctx *attestation.AttestationContext) error {
 	return fmt.Errorf("no tar file found")
 }
 
-func (a *Attestor) parseMaifest(ctx *attestation.AttestationContext) error {
+func (a *Attestor) parseManifest(ctx *attestation.AttestationContext) error {
 	f, err := os.Open(a.tarFilePath)
 	if err != nil {
 		err = fmt.Errorf("error opening tar file: %w", err)
 		return err
 	}
+	defer f.Close()
 
+	// Cache the entry points and content-addressed blobs needed by both the
+	// OCI image-layout and legacy Docker archive parsers.
 	tarReader := tar.NewReader(f)
+	files := make(map[string][]byte)
 	for {
 		h, err := tarReader.Next()
 		if err == io.EOF {
@@ -215,35 +221,263 @@ func (a *Attestor) parseMaifest(ctx *attestation.AttestationContext) error {
 		}
 
 		if err != nil {
-			return err
+			return fmt.Errorf("read OCI archive %q: %w", a.tarFilePath, err)
 		}
 
 		if h.FileInfo().IsDir() {
 			continue
 		}
-		if h.Name == "manifest.json" {
-			a.ManifestRaw = make([]byte, h.Size)
-			_, err = tarReader.Read(a.ManifestRaw)
-			if err != nil || err == io.EOF {
-				break
-			}
-			break
+
+		name := strings.TrimPrefix(path.Clean(h.Name), "./")
+		if name != "manifest.json" && name != "index.json" && !strings.HasPrefix(name, "blobs/") {
+			continue
 		}
+
+		b, err := io.ReadAll(tarReader)
+		if err != nil {
+			return fmt.Errorf("read OCI archive entry %q: %w", name, err)
+		}
+		files[name] = b
 	}
+
+	manifestRaw, ok := files["manifest.json"]
+
+	// Prefer the OCI image-layout entry point when a hybrid archive contains
+	// both index.json and Docker's compatibility manifest.json.
+	if indexRaw, ok := files["index.json"]; ok {
+		if manifestRaw != nil {
+			a.logDockerManifestAttestation(ctx, manifestRaw)
+		}
+		return a.parseOCIManifest(ctx, indexRaw, files)
+	}
+
+	if !ok {
+		return fmt.Errorf("archive %q contains neither OCI index.json nor Docker manifest.json", a.tarFilePath)
+	}
+
+	log.Debug("(attestation/oci) index.json not found; parsing legacy Docker manifest.json")
+	return a.parseDockerManifest(ctx, manifestRaw)
+}
+
+func (a *Attestor) logDockerManifestAttestation(ctx *attestation.AttestationContext, manifestRaw []byte) {
+	dockerAttestor := New()
+	dockerAttestor.TarDigest = a.TarDigest
+	dockerAttestor.tarFilePath = a.tarFilePath
+
+	if err := dockerAttestor.parseDockerManifest(ctx, manifestRaw); err != nil {
+		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
+		return
+	}
+
+	imageID, err := dockerAttestor.Manifest[0].getImageID(ctx, a.tarFilePath)
+	if err != nil {
+		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
+		return
+	}
+	diffIDs, err := dockerAttestor.Manifest[0].getLayerDIFFIDs(ctx, a.tarFilePath)
+	if err != nil {
+		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
+		return
+	}
+
+	dockerAttestor.ImageID = imageID
+	dockerAttestor.LayerDiffIDs = diffIDs
+	dockerAttestor.ImageTags = dockerAttestor.Manifest[0].RepoTags
+
+	output, err := json.MarshalIndent(dockerAttestor, "", "  ")
+	if err != nil {
+		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
+		return
+	}
+	log.Infof("FYI Docker manifest.json attestation:\n%s", output)
+}
+
+func (a *Attestor) parseDockerManifest(ctx *attestation.AttestationContext, manifestRaw []byte) error {
+	a.ManifestRaw = manifestRaw
 
 	manifestDigest, err := cryptoutil.CalculateDigestSetFromBytes(a.ManifestRaw, ctx.Hashes())
 	if err != nil {
-		return err
+		return fmt.Errorf("calculate Docker manifest.json digest: %w", err)
 	}
 
 	a.ManifestDigest = manifestDigest
 
-	err = json.Unmarshal(a.ManifestRaw, &a.Manifest)
-	if err != nil {
-		return err
+	if err := json.Unmarshal(a.ManifestRaw, &a.Manifest); err != nil {
+		return fmt.Errorf("parse Docker manifest.json: %w", err)
+	}
+
+	if len(a.Manifest) == 0 {
+		return fmt.Errorf("Docker manifest.json contains no image entries")
 	}
 
 	return nil
+}
+
+func (a *Attestor) parseOCIManifest(ctx *attestation.AttestationContext, indexRaw []byte, files map[string][]byte) error {
+	type imageManifest struct {
+		manifest Manifest
+		raw      []byte
+	}
+
+	var images []imageManifest
+	visited := make(map[string]struct{})
+
+	// OCI indexes form a descriptor graph and may point to nested indexes.
+	// Tags on a parent index are inherited by image manifests below it.
+	var walkIndex func([]byte, []string, string) error
+	walkIndex = func(raw []byte, inheritedTags []string, source string) error {
+		var index v1.Index
+		if err := json.Unmarshal(raw, &index); err != nil {
+			return fmt.Errorf("parse OCI index %s: %w", source, err)
+		}
+
+		for descriptorIndex, descriptor := range index.Manifests {
+			descriptorTags := tagsFromDescriptor(descriptor, inheritedTags)
+
+			blobPath, err := descriptorPath(descriptor)
+			if err != nil {
+				return fmt.Errorf("resolve descriptor %d in OCI index %s: %w", descriptorIndex, source, err)
+			}
+			if _, ok := visited[blobPath]; ok {
+				continue
+			}
+			visited[blobPath] = struct{}{}
+
+			descriptorRaw, ok := files[blobPath]
+			if !ok {
+				return fmt.Errorf(
+					"OCI index %s references missing %s descriptor blob %q",
+					source,
+					descriptor.MediaType,
+					blobPath,
+				)
+			}
+
+			switch descriptor.MediaType {
+			// Recursively traverse the index.
+			case v1.MediaTypeImageIndex:
+				if err := walkIndex(descriptorRaw, descriptorTags, descriptor.Digest.String()); err != nil {
+					return fmt.Errorf("follow nested OCI index %s: %w", descriptor.Digest, err)
+				}
+			// Parse the found manifest.
+			case v1.MediaTypeImageManifest:
+				var manifest v1.Manifest
+				if err := json.Unmarshal(descriptorRaw, &manifest); err != nil {
+					return fmt.Errorf("parse OCI image manifest %s: %w", descriptor.Digest, err)
+				}
+
+				// Artifacts and subject-linked manifests are not runnable images.
+				if manifest.ArtifactType != "" || manifest.Subject != nil || manifest.Config.MediaType != v1.MediaTypeImageConfig {
+					log.Debugf("(attestation/oci) skipping non-runnable manifest %s", descriptor.Digest)
+					continue
+				}
+
+				configPath, err := descriptorPath(manifest.Config)
+				if err != nil {
+					return fmt.Errorf("resolve config descriptor in OCI image manifest %s: %w", descriptor.Digest, err)
+				}
+
+				layerPaths, runnable, err := parseLayers(manifest.Layers, descriptor.Digest.String())
+				if err != nil {
+					return err
+				}
+				if !runnable {
+					log.Debugf("(attestation/oci) skipping non-runnable manifest %s", descriptor.Digest)
+					continue
+				}
+
+				images = append(images, imageManifest{
+					manifest: Manifest{
+						Config:   configPath,
+						RepoTags: descriptorTags,
+						Layers:   layerPaths,
+					},
+					raw: descriptorRaw,
+				})
+			default:
+				log.Debugf("(attestation/oci) skipping unsupported descriptor media type %q", descriptor.MediaType)
+			}
+		}
+
+		return nil
+	}
+
+	if err := walkIndex(indexRaw, nil, "index.json"); err != nil {
+		return err
+	}
+	if len(images) == 0 {
+		return fmt.Errorf("OCI index graph contains no runnable image manifests")
+	}
+
+	a.Manifest = make([]Manifest, 0, len(images))
+	for _, image := range images {
+		a.Manifest = append(a.Manifest, image.manifest)
+	}
+
+	// v0.1 has singular raw/digest fields, so the first runnable image remains
+	// the primary image while Manifest reports every runnable image discovered.
+	a.ManifestRaw = images[0].raw
+	manifestDigest, err := cryptoutil.CalculateDigestSetFromBytes(a.ManifestRaw, ctx.Hashes())
+	if err != nil {
+		return fmt.Errorf("calculate primary OCI image manifest digest: %w", err)
+	}
+	a.ManifestDigest = manifestDigest
+
+	return nil
+}
+
+func descriptorPath(descriptor v1.Descriptor) (string, error) {
+	if descriptor.Digest == "" {
+		return "", fmt.Errorf("OCI descriptor has an empty digest")
+	}
+	if err := descriptor.Digest.Validate(); err != nil {
+		return "", fmt.Errorf("OCI descriptor has an invalid digest %q: %w", descriptor.Digest, err)
+	}
+
+	algorithm := descriptor.Digest.Algorithm()
+	encoded := descriptor.Digest.Encoded()
+
+	return path.Join("blobs", algorithm.String(), encoded), nil
+}
+
+func tagsFromDescriptor(descriptor v1.Descriptor, inherited []string) []string {
+	// containerd records a fully qualified image name, while the standard OCI
+	// annotation commonly contains only the local reference name.
+	if name := descriptor.Annotations["io.containerd.image.name"]; name != "" {
+		return []string{name}
+	}
+	if name := descriptor.Annotations[v1.AnnotationRefName]; name != "" {
+		return []string{name}
+	}
+
+	return append([]string(nil), inherited...)
+}
+
+func parseLayers(layers []v1.Descriptor, manifestDigest string) ([]string, bool, error) {
+	layerPaths := make([]string, 0, len(layers))
+	for layerIndex, layer := range layers {
+		// Only OCI and Docker rootfs layers belong to runnable images.
+		switch layer.MediaType {
+		case v1.MediaTypeImageLayer,
+			v1.MediaTypeImageLayerGzip,
+			v1.MediaTypeImageLayerZstd,
+			"application/vnd.docker.image.rootfs.diff.tar",
+			"application/vnd.docker.image.rootfs.diff.tar.gzip",
+			"application/vnd.docker.image.rootfs.foreign.diff.tar.gzip":
+			layerPath, err := descriptorPath(layer)
+			if err != nil {
+				return nil, false, fmt.Errorf(
+					"resolve layer descriptor %d in OCI image manifest %s: %w",
+					layerIndex, manifestDigest, err,
+				)
+			}
+			layerPaths = append(layerPaths, layerPath)
+		default:
+			return nil, false, nil
+		}
+	}
+
+	return layerPaths, true, nil
 }
 
 func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {

--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -16,13 +16,10 @@ package oci
 
 import (
 	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"crypto"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -75,6 +72,7 @@ type Attestor struct {
 	ImageID        cryptoutil.DigestSet   `json:"imageid"`
 	ManifestRaw    []byte                 `json:"manifestraw"`
 	ManifestDigest cryptoutil.DigestSet   `json:"manifestdigest"`
+	files          map[string][]byte      `json:"-"`
 	tarFilePath    string                 `json:"-"`
 }
 
@@ -161,9 +159,24 @@ func (a *Attestor) Attest(ctx *attestation.AttestationContext) error {
 		return err
 	}
 
-	layerDiffIDs, err := a.Manifest[0].getLayerDIFFIDs(ctx, a.tarFilePath)
-	if err != nil {
+	var config v1.Image
+	configRaw, ok := a.files[a.Manifest[0].Config]
+	if !ok {
+		return fmt.Errorf("could not find config %q in tar file", a.Manifest[0].Config)
+	}
+	if err := json.Unmarshal(configRaw, &config); err != nil {
 		return err
+	}
+
+	layerDiffIDs := make([]cryptoutil.DigestSet, 0, len(config.RootFS.DiffIDs))
+	for _, diffID := range config.RootFS.DiffIDs {
+		digestSet, err := cryptoutil.NewDigestSet(map[string]string{
+			diffID.Algorithm().String(): diffID.Encoded(),
+		})
+		if err != nil {
+			return err
+		}
+		layerDiffIDs = append(layerDiffIDs, digestSet)
 	}
 
 	a.ImageID = imageID
@@ -213,7 +226,7 @@ func (a *Attestor) parseManifest(ctx *attestation.AttestationContext) error {
 	// Cache the entry points and content-addressed blobs needed by both the
 	// OCI image-layout and legacy Docker archive parsers.
 	tarReader := tar.NewReader(f)
-	files := make(map[string][]byte)
+	a.files = make(map[string][]byte)
 	for {
 		h, err := tarReader.Next()
 		if err == io.EOF {
@@ -229,7 +242,7 @@ func (a *Attestor) parseManifest(ctx *attestation.AttestationContext) error {
 		}
 
 		name := strings.TrimPrefix(path.Clean(h.Name), "./")
-		if name != "manifest.json" && name != "index.json" && !strings.HasPrefix(name, "blobs/") {
+		if name != "manifest.json" && name != "index.json" && !strings.HasPrefix(name, "blobs/") && !strings.HasSuffix(name, ".json") {
 			continue
 		}
 
@@ -237,16 +250,16 @@ func (a *Attestor) parseManifest(ctx *attestation.AttestationContext) error {
 		if err != nil {
 			return fmt.Errorf("read OCI archive entry %q: %w", name, err)
 		}
-		files[name] = b
+		a.files[name] = b
 	}
 
 	// Prefer the OCI image-layout entry point when a hybrid archive contains
 	// both index.json and Docker's compatibility manifest.json.
-	if indexRaw, ok := files["index.json"]; ok {
-		return a.parseOCIManifest(ctx, indexRaw, files)
+	if indexRaw, ok := a.files["index.json"]; ok {
+		return a.parseOCIManifest(ctx, indexRaw, a.files)
 	}
 
-	manifestRaw, ok := files["manifest.json"]
+	manifestRaw, ok := a.files["manifest.json"]
 	if !ok {
 		return fmt.Errorf("archive %q contains neither OCI index.json nor Docker manifest.json", a.tarFilePath)
 	}
@@ -465,65 +478,4 @@ func (a *Attestor) Subjects() map[string]cryptoutil.DigestSet {
 		subj[fmt.Sprintf("layerdiffid%02d:%s", layer, a.LayerDiffIDs[layer][cryptoutil.DigestValue{Hash: crypto.SHA256}])] = a.LayerDiffIDs[layer]
 	}
 	return subj
-}
-
-func (m *Manifest) getLayerDIFFIDs(ctx *attestation.AttestationContext, tarFilePath string) ([]cryptoutil.DigestSet, error) {
-	var layerDiffIDs []cryptoutil.DigestSet
-
-	tarFile, err := os.Open(tarFilePath)
-	if err != nil {
-		return nil, err
-	}
-	defer tarFile.Close()
-
-	tarReader := tar.NewReader(tarFile)
-	for {
-		h, err := tarReader.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		if h.FileInfo().IsDir() {
-			continue
-		}
-		for _, layerFile := range m.Layers {
-			if h.Name == layerFile {
-				b := make([]byte, h.Size)
-
-				_, err := tarReader.Read(b)
-				if err != nil && err != io.EOF {
-					return nil, err
-				}
-
-				contentType := http.DetectContentType(b)
-				if contentType == "application/x-gzip" {
-					breader, err := gzip.NewReader(bytes.NewReader(b))
-					if err != nil {
-						return nil, err
-					}
-					defer breader.Close()
-					c, err := io.ReadAll(breader)
-					if err != nil {
-						return nil, err
-					}
-					layerDiffID, err := cryptoutil.CalculateDigestSetFromBytes(c, ctx.Hashes())
-					if err != nil {
-						return nil, err
-					}
-					layerDiffIDs = append(layerDiffIDs, layerDiffID)
-
-				} else {
-					layerDiffID, err := cryptoutil.CalculateDigestSetFromBytes(b, ctx.Hashes())
-					if err != nil {
-						return nil, err
-					}
-					layerDiffIDs = append(layerDiffIDs, layerDiffID)
-				}
-
-			}
-		}
-	}
-	return layerDiffIDs, nil
 }

--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -270,7 +270,7 @@ func (a *Attestor) parseDockerManifest(ctx *attestation.AttestationContext, mani
 	}
 
 	if len(a.Manifest) == 0 {
-		return fmt.Errorf("Docker manifest.json contains no image entries")
+		return fmt.Errorf("docker manifest.json contains no image entries")
 	}
 
 	return nil

--- a/attestation/oci/oci.go
+++ b/attestation/oci/oci.go
@@ -240,56 +240,19 @@ func (a *Attestor) parseManifest(ctx *attestation.AttestationContext) error {
 		files[name] = b
 	}
 
-	manifestRaw, ok := files["manifest.json"]
-
 	// Prefer the OCI image-layout entry point when a hybrid archive contains
 	// both index.json and Docker's compatibility manifest.json.
 	if indexRaw, ok := files["index.json"]; ok {
-		if manifestRaw != nil {
-			a.logDockerManifestAttestation(ctx, manifestRaw)
-		}
 		return a.parseOCIManifest(ctx, indexRaw, files)
 	}
 
+	manifestRaw, ok := files["manifest.json"]
 	if !ok {
 		return fmt.Errorf("archive %q contains neither OCI index.json nor Docker manifest.json", a.tarFilePath)
 	}
 
 	log.Debug("(attestation/oci) index.json not found; parsing legacy Docker manifest.json")
 	return a.parseDockerManifest(ctx, manifestRaw)
-}
-
-func (a *Attestor) logDockerManifestAttestation(ctx *attestation.AttestationContext, manifestRaw []byte) {
-	dockerAttestor := New()
-	dockerAttestor.TarDigest = a.TarDigest
-	dockerAttestor.tarFilePath = a.tarFilePath
-
-	if err := dockerAttestor.parseDockerManifest(ctx, manifestRaw); err != nil {
-		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
-		return
-	}
-
-	imageID, err := dockerAttestor.Manifest[0].getImageID(ctx, a.tarFilePath)
-	if err != nil {
-		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
-		return
-	}
-	diffIDs, err := dockerAttestor.Manifest[0].getLayerDIFFIDs(ctx, a.tarFilePath)
-	if err != nil {
-		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
-		return
-	}
-
-	dockerAttestor.ImageID = imageID
-	dockerAttestor.LayerDiffIDs = diffIDs
-	dockerAttestor.ImageTags = dockerAttestor.Manifest[0].RepoTags
-
-	output, err := json.MarshalIndent(dockerAttestor, "", "  ")
-	if err != nil {
-		log.Infof("FYI Docker manifest.json comparison failed: %v", err)
-		return
-	}
-	log.Infof("FYI Docker manifest.json attestation:\n%s", output)
 }
 
 func (a *Attestor) parseDockerManifest(ctx *attestation.AttestationContext, manifestRaw []byte) error {

--- a/attestation/oci/oci_test.go
+++ b/attestation/oci/oci_test.go
@@ -17,12 +17,16 @@ package oci
 import (
 	"crypto"
 	"encoding/base64"
+	"encoding/json"
 	"os"
 	"testing"
 
 	"github.com/in-toto/go-witness/attestation"
 	"github.com/in-toto/go-witness/cryptoutil"
 	testproducter "github.com/in-toto/go-witness/internal/attestors/test"
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,6 +102,90 @@ func TestAttestor_Attest(t *testing.T) {
 	require.Equal(t, manifestDigest, a.ManifestDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}])
 
 	require.NoError(t, err)
+}
+
+func TestAttestor_ManifestTraversal(t *testing.T) {
+	configDescriptor := v1.Descriptor{
+		MediaType: v1.MediaTypeImageConfig,
+		Digest:    digest.FromString("config"),
+		Size:      6,
+	}
+	layerDescriptor := v1.Descriptor{
+		MediaType: v1.MediaTypeImageLayer,
+		Digest:    digest.FromString("layer"),
+		Size:      5,
+	}
+	manifest := v1.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: v1.MediaTypeImageManifest,
+		Config:    configDescriptor,
+		Layers:    []v1.Descriptor{layerDescriptor},
+	}
+	manifestRaw, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	manifestDescriptor := v1.Descriptor{
+		MediaType: v1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifestRaw),
+		Size:      int64(len(manifestRaw)),
+		Platform:  &v1.Platform{Architecture: "arm64", OS: "linux"},
+	}
+	attestationRaw := []byte(`{"schemaVersion":2}`)
+	attestationDescriptor := v1.Descriptor{
+		MediaType: v1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(attestationRaw),
+		Size:      int64(len(attestationRaw)),
+		Annotations: map[string]string{
+			"vnd.docker.reference.type": "attestation-manifest",
+		},
+		Platform: &v1.Platform{Architecture: "unknown", OS: "unknown"},
+	}
+	nestedIndex := v1.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: v1.MediaTypeImageIndex,
+		Manifests: []v1.Descriptor{manifestDescriptor, attestationDescriptor},
+	}
+	nestedIndexRaw, err := json.Marshal(nestedIndex)
+	require.NoError(t, err)
+
+	nestedIndexDescriptor := v1.Descriptor{
+		MediaType: v1.MediaTypeImageIndex,
+		Digest:    digest.FromBytes(nestedIndexRaw),
+		Size:      int64(len(nestedIndexRaw)),
+		Annotations: map[string]string{
+			"io.containerd.image.name": "docker.io/library/dtest-img:latest",
+			v1.AnnotationRefName:       "latest",
+		},
+	}
+	rootIndex := v1.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: v1.MediaTypeImageIndex,
+		Manifests: []v1.Descriptor{nestedIndexDescriptor},
+	}
+	rootIndexRaw, err := json.Marshal(rootIndex)
+	require.NoError(t, err)
+
+	files := map[string][]byte{
+		descriptorPathForTest(nestedIndexDescriptor): nestedIndexRaw,
+		descriptorPathForTest(manifestDescriptor):    manifestRaw,
+		descriptorPathForTest(attestationDescriptor): attestationRaw,
+	}
+
+	a := New()
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{a})
+	require.NoError(t, err)
+	require.NoError(t, a.parseOCIManifest(ctx, rootIndexRaw, files))
+
+	require.Len(t, a.Manifest, 1)
+	require.Equal(t, descriptorPathForTest(configDescriptor), a.Manifest[0].Config)
+	require.Equal(t, []string{"docker.io/library/dtest-img:latest"}, a.Manifest[0].RepoTags)
+	require.Equal(t, []string{descriptorPathForTest(layerDescriptor)}, a.Manifest[0].Layers)
+	require.Equal(t, manifestRaw, a.ManifestRaw)
+	require.Equal(t, manifestDescriptor.Digest.Encoded(), a.ManifestDigest[cryptoutil.DigestValue{Hash: crypto.SHA256}])
+}
+
+func descriptorPathForTest(descriptor v1.Descriptor) string {
+	return "blobs/" + descriptor.Digest.Algorithm().String() + "/" + descriptor.Digest.Encoded()
 }
 
 const (


### PR DESCRIPTION
## What this PR does / why we need it

The current OCI attestor relies on `docker save` based `manifest.json` files to build up the attestation. This is not a file that is required or expected in an OCI image. 

As the issue points out, the current behaviour breaks for OCI compliant images (built and saved using for instance with `buildah --format oci`) error out since they do not have a `manifest.json`.

This PR makes the following changes:
- Detects `index.json` and uses that as the primary source for building the attestation.
- To preserve backwards compatibility with `docker save`, it falls back to `manifest.json` in case `index.json` is missing. 
- Adds a proper parser for OCI manifests, say for instance having the ability to traverse nester indices and detecting runnable images.
- Preserves the current schema for an OCI attestor (testing confirms that manually traversal of `index.json` does report the same things as reading the `manifest.json` for docker images)
- Adds unit-test for the new parser.

Notes:
The current schema for OCI relies heavily on what a docker `manifest.json` looks like, this is not super-ideal. For instance, when an image has multiple manifests, we do not do a great job of reporting those. We also do not have a good way of reporting non-runnable layers that the image might contain (e.g. `application/vnd.in-toto+json`, `application/spdx+json`)

We should look into updating the schema for an OCI attestor, and having a discussion about what the backward-compatibility options should be. (CCing @Vyom-Yadav for this)

## Which issue(s) this PR fixes (optional)
Fixes #686 

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [X] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
