### PR TITLE
fix(ci): add write permissions to release workflow to allow attestation creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
     needs: [ unit-test ]
     uses: ./.github/workflows/witness.yml
     permissions:
+      id-token: write # This is required for requesting the JWT
       contents: read
     with:
       pull_request: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## What this PR does / why we need it

fix(ci): add write permissions to release workflow to allow attestation creation
