### PR TITLE
Add HTTP MITM proxy support to networktrace attestor

### DIFF
--- a/attestation/networktrace/networktrace.go
+++ b/attestation/networktrace/networktrace.go
@@ -18,6 +18,8 @@ package networktrace
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"github.com/in-toto/go-witness/attestation/networktrace/proxy"
 	"github.com/in-toto/go-witness/attestation/networktrace/types"
 	"github.com/in-toto/go-witness/log"
+	"github.com/in-toto/go-witness/registry"
 	"github.com/invopop/jsonschema"
 )
 
@@ -41,9 +44,212 @@ var (
 )
 
 func init() {
-	attestation.RegisterAttestation(Name, Type, RunType, func() attestation.Attestor {
-		return New()
-	})
+	attestation.RegisterAttestation(
+		Name,
+		Type,
+		RunType,
+		func() attestation.Attestor {
+			return New()
+		},
+		registry.IntConfigOption(
+			"proxy-port",
+			"Port for the network trace proxy to listen on",
+			int(types.DefaultProxyPort),
+			func(a attestation.Attestor, val int) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				if val < 1 || val > math.MaxUint16 {
+					return a, fmt.Errorf("proxy-port %d out of valid range [1, %d]", val, math.MaxUint16)
+				}
+				WithProxyPort(uint16(val))(nt)
+				return nt, nil
+			},
+		),
+		registry.StringConfigOption(
+			"proxy-bind-ipv4",
+			"IPv4 address for the proxy to bind to",
+			types.DefaultProxyBindIPv4,
+			func(a attestation.Attestor, val string) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithProxyBindIPv4(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.BoolConfigOption(
+			"enable-http-inspection",
+			"Enable HTTP/HTTPS traffic inspection via MITM proxy",
+			true,
+			func(a attestation.Attestor, val bool) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithEnableHTTPInspection(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.BoolConfigOption(
+			"generate-ca",
+			"Auto-generate a CA certificate and key for TLS interception",
+			true,
+			func(a attestation.Attestor, val bool) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithGenerateCA(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.StringConfigOption(
+			"ca-cert-path",
+			"Path to the CA certificate PEM file for TLS interception",
+			types.DefaultCaCertPath,
+			func(a attestation.Attestor, val string) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithCACertPath(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.StringConfigOption(
+			"ca-key-path",
+			"Path to the CA key PEM file for TLS interception",
+			types.DefaultCaKeyPath,
+			func(a attestation.Attestor, val string) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithCAKeyPath(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.BoolConfigOption(
+			"skip-verify",
+			"Skip TLS certificate verification for intercepted connections",
+			false,
+			func(a attestation.Attestor, val bool) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithSkipVerify(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.IntSliceConfigOption(
+			"observe-pids",
+			"PIDs to observe network activity for",
+			nil,
+			func(a attestation.Attestor, val []int) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				pids := make([]uint32, 0, len(val))
+				for _, pid := range val {
+					if pid <= 0 {
+						return a, fmt.Errorf("invalid PID %d: must be positive", pid)
+					}
+					if pid > math.MaxUint32 {
+						return a, fmt.Errorf("invalid PID %d: exceeds uint32 range", pid)
+					}
+					pids = append(pids, uint32(pid))
+				}
+				WithObservePIDs(pids)(nt)
+				return nt, nil
+			},
+		),
+		registry.StringSliceConfigOption(
+			"observe-cgroups",
+			"Cgroup paths to observe network activity for",
+			nil,
+			func(a attestation.Attestor, val []string) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithObserveCgroups(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.StringSliceConfigOption(
+			"observe-commands",
+			"Command names to observe network activity for",
+			nil,
+			func(a attestation.Attestor, val []string) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithObserveCommands(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.BoolConfigOption(
+			"observe-child-tree",
+			"Observe network activity for child processes",
+			true,
+			func(a attestation.Attestor, val bool) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithObserveChildTree(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.BoolConfigOption(
+			"record-payload",
+			"Record raw payload data in network connections",
+			false,
+			func(a attestation.Attestor, val bool) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithPayloadRecordPayload(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.BoolConfigOption(
+			"record-payload-hash",
+			"Record SHA256 hash of payload data",
+			true,
+			func(a attestation.Attestor, val bool) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				WithPayloadRecordPayloadHash(val)(nt)
+				return nt, nil
+			},
+		),
+		registry.Int64ConfigOption(
+			"max-payload-size",
+			"Maximum size in bytes to store raw payload (0 for unlimited)",
+			int64(types.DefaultPayloadConfig().MaxPayloadSize),
+			func(a attestation.Attestor, val int64) (attestation.Attestor, error) {
+				nt, ok := a.(*Attestor)
+				if !ok {
+					return a, fmt.Errorf("invalid attestor type: %T", a)
+				}
+				if val < 0 {
+					return a, fmt.Errorf("max-payload-size %d must be non-negative", val)
+				}
+				WithPayloadMaxPayloadSize(val)(nt)
+				return nt, nil
+			},
+		),
+	)
 }
 
 // NetworkTrace contains the recorded network activity during command execution
@@ -68,10 +274,8 @@ type NetworkTrace struct {
 
 // Attestor implements the network trace attestation
 type Attestor struct {
-	config       types.Config
 	NetworkTrace NetworkTrace `json:"network_trace"`
-
-	hooks *attestation.ExecuteHooks
+	hooks        *attestation.ExecuteHooks
 }
 
 func (n *Attestor) DeclareHooks(hooks *attestation.ExecuteHooks) error {
@@ -90,16 +294,104 @@ func (n *Attestor) DeclareHooks(hooks *attestation.ExecuteHooks) error {
 	return nil
 }
 
-// New creates a new network trace attestor with default configuration
-func New() *Attestor {
-	return &Attestor{
-		config: types.DefaultConfig(),
+func WithProxyPort(port uint16) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.ProxyPort = port
 	}
 }
 
-func NewWithConfig(config types.Config) *Attestor {
+func WithProxyBindIPv4(addr string) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.ProxyBindIPv4 = addr
+	}
+}
+
+func WithEnableHTTPInspection(enabled bool) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.EnableHTTPInspection = enabled
+	}
+}
+
+func WithGenerateCA(generate bool) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.GenerateCA = generate
+	}
+}
+
+func WithCACertPath(path string) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.CACertPath = path
+	}
+}
+
+func WithCAKeyPath(path string) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.CAKeyPath = path
+	}
+}
+
+func WithSkipVerify(skip bool) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.SkipVerify = skip
+	}
+}
+
+func WithObservePIDs(pids []uint32) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.ObservePIDs = pids
+	}
+}
+
+func WithObserveCgroups(cgroups []string) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.ObserveCgroups = cgroups
+	}
+}
+
+func WithObserveCommands(commands []string) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.ObserveCommands = commands
+	}
+}
+
+func WithObserveChildTree(observe bool) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.ObserveChildTree = observe
+	}
+}
+
+func WithPayloadRecordPayload(record bool) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.Payload.RecordPayload = record
+	}
+}
+
+func WithPayloadRecordPayloadHash(record bool) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.Payload.RecordPayloadHash = record
+	}
+}
+
+func WithPayloadMaxPayloadSize(maxSize int64) func(*Attestor) {
+	return func(a *Attestor) {
+		a.NetworkTrace.Config.Payload.MaxPayloadSize = maxSize
+	}
+}
+
+// New creates a new network trace attestor with default configuration
+func New() *Attestor {
 	return &Attestor{
-		config: config,
+		NetworkTrace: NetworkTrace{
+			Config: types.DefaultConfig(),
+		},
+	}
+}
+
+func NewWithConfig(cfg types.Config) *Attestor {
+	return &Attestor{
+		NetworkTrace: NetworkTrace{
+			Config: cfg,
+		},
 	}
 }
 
@@ -162,8 +454,8 @@ func (n *Attestor) Attest(ctx *attestation.AttestationContext) error {
 func (n *Attestor) initBPF() (*bpf.Maps, func(), error) {
 	bpfConfig := bpf.LoadConfig{
 		CgroupPath: "/sys/fs/cgroup", // TODO: allow user to configure
-		ProxyPort:  n.config.ProxyPort,
-		ProxyIPv4:  n.config.ProxyBindIPv4,
+		ProxyPort:  n.NetworkTrace.Config.ProxyPort,
+		ProxyIPv4:  n.NetworkTrace.Config.ProxyBindIPv4,
 	}
 
 	state, err := bpf.Load(bpfConfig)
@@ -196,19 +488,20 @@ func (n *Attestor) initProxies(ctx *attestation.AttestationContext, bpfMaps *bpf
 		}
 	})
 
+	cfg := n.NetworkTrace.Config
 	var httpProxy *proxy.HTTPProxy
-	if n.config.EnableHTTPInspection {
-		cm, err := proxy.NewCAManager(n.config.CAKeyPath, n.config.CACertPath, n.config.GenerateCA)
+	if cfg.EnableHTTPInspection {
+		cm, err := proxy.NewCAManager(cfg.CAKeyPath, cfg.CACertPath, cfg.GenerateCA)
 		if err != nil {
 			log.Errorf("[networktrace] failed to create CA manager: %v", err)
 			return nil, err
 		}
 		n.NetworkTrace.CACertPEM = cm.CertPEM()
-		httpProxy = proxy.NewHTTPProxy(cm, n.config.Payload, runtime.connChannel, n.config.SkipVerify)
+		httpProxy = proxy.NewHTTPProxy(cm, cfg.Payload, runtime.connChannel, cfg.SkipVerify)
 	}
 
 	// Create and start proxy
-	tcpProxy := proxy.NewTCPProxy(bpfMaps, httpProxy, n.config.ProxyPort, n.config.ProxyBindIPv4, true, n.config.Payload, runtime.connChannel)
+	tcpProxy := proxy.NewTCPProxy(bpfMaps, httpProxy, cfg.ProxyPort, cfg.ProxyBindIPv4, true, cfg.Payload, runtime.connChannel)
 
 	var proxyCtx context.Context
 	proxyCtx, runtime.cancelProxy = context.WithCancel(ctx.Context())
@@ -232,17 +525,12 @@ func (n *Attestor) initProxies(ctx *attestation.AttestationContext, bpfMaps *bpf
 
 // registerHooks sets up PreExec and PreExit hooks for command lifecycle
 func (n *Attestor) registerHooks(bpfMaps *bpf.Maps, runtime *proxyRuntime) error {
-	if n.config.ObservePIDs == nil {
-		n.config.ObservePIDs = make([]uint32, 0)
-	}
-
 	// PreExec: called when command starts, adds PID to BPF filter
 	r1, err := n.hooks.RegisterHook(attestation.StagePreExec, Name, func(pid int) error {
 		log.Debugf("[networktrace] PreExec hook triggered, tracking PID=%d", pid)
-		n.config.ObservePIDs = append(n.config.ObservePIDs, uint32(pid))
+		n.NetworkTrace.Config.ObservePIDs = append(n.NetworkTrace.Config.ObservePIDs, uint32(pid))
 		n.NetworkTrace.StartTime = time.Now()
-		n.NetworkTrace.Config = n.config
-		err := bpfMaps.LoadUserConfig(n.config)
+		err := bpfMaps.LoadUserConfig(n.NetworkTrace.Config)
 		if err != nil {
 			log.Errorf("[networktrace] failed to load user config: %v", err)
 		}

--- a/attestation/networktrace/networktrace.go
+++ b/attestation/networktrace/networktrace.go
@@ -60,6 +60,10 @@ type NetworkTrace struct {
 
 	// Configuration used (for reproducibility/auditability)
 	Config types.Config `json:"config"`
+
+	// CA certificate used for TLS interception (PEM encoded)
+	// Included so verifiers understand what was trusted during attestation
+	CACertPEM string `json:"ca_cert_pem,omitempty"`
 }
 
 // Attestor implements the network trace attestation
@@ -192,8 +196,19 @@ func (n *Attestor) initProxies(ctx *attestation.AttestationContext, bpfMaps *bpf
 		}
 	})
 
+	var httpProxy *proxy.HTTPProxy
+	if n.config.EnableHTTPInspection {
+		cm, err := proxy.NewCAManager(n.config.CAKeyPath, n.config.CACertPath, n.config.GenerateCA)
+		if err != nil {
+			log.Errorf("[networktrace] failed to create CA manager: %v", err)
+			return nil, err
+		}
+		n.NetworkTrace.CACertPEM = cm.CertPEM()
+		httpProxy = proxy.NewHTTPProxy(cm, n.config.Payload, runtime.connChannel, n.config.SkipVerify)
+	}
+
 	// Create and start proxy
-	tcpProxy := proxy.NewTCPProxy(bpfMaps, n.config.ProxyPort, n.config.ProxyBindIPv4, true, n.config.Payload, runtime.connChannel)
+	tcpProxy := proxy.NewTCPProxy(bpfMaps, httpProxy, n.config.ProxyPort, n.config.ProxyBindIPv4, true, n.config.Payload, runtime.connChannel)
 
 	var proxyCtx context.Context
 	proxyCtx, runtime.cancelProxy = context.WithCancel(ctx.Context())

--- a/attestation/networktrace/networktrace_test.go
+++ b/attestation/networktrace/networktrace_test.go
@@ -22,7 +22,11 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -57,6 +61,7 @@ func TestNewWithConfig(t *testing.T) {
 			RecordPayloadHash: true,
 			MaxPayloadSize:    2048,
 		},
+		EnableHTTPInspection: false,
 	}
 
 	attestor := NewWithConfig(config)
@@ -209,6 +214,7 @@ func TestIntegrationNetworkTrace(t *testing.T) {
 			RecordPayloadHash: true,
 			MaxPayloadSize:    1024 * 1024,
 		},
+		EnableHTTPInspection: false,
 	}
 
 	networkAttestor := NewWithConfig(config)
@@ -283,6 +289,7 @@ func TestIntegrationZeroByteConnection(t *testing.T) {
 			RecordPayloadHash: true,
 			MaxPayloadSize:    1024,
 		},
+		EnableHTTPInspection: false,
 	}
 
 	networkAttestor := NewWithConfig(config)
@@ -357,6 +364,7 @@ func TestIntegrationHangingConnectionTeardown(t *testing.T) {
 			RecordPayloadHash: true,
 			MaxPayloadSize:    1024,
 		},
+		EnableHTTPInspection: false,
 	}
 	networkAttestor := NewWithConfig(config)
 
@@ -382,6 +390,263 @@ func TestIntegrationHangingConnectionTeardown(t *testing.T) {
 		require.NoError(t, err, "Attestors should run successfully and shut down cleanly")
 	case <-time.After(10 * time.Second):
 		t.Fatal("DEADLOCK DETECTED: Test timed out! The proxy failed to forcefully close lingering connections during shutdown, causing io.Copy to block forever.")
+	}
+}
+
+func TestIntegrationCurlHTTPS(t *testing.T) {
+	skipIfNotRoot(t)
+
+	// Start a test HTTPS server
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("Hello HTTPS"))
+	}))
+	defer server.Close()
+
+	// Parse server port
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	_, portStr, err := net.SplitHostPort(serverURL.Host)
+	require.NoError(t, err)
+	serverPort, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	config := types.Config{
+		ObserveChildTree: true,
+		ProxyPort:        testProxyPort + 2,
+		ProxyBindIPv4:    "127.0.0.1",
+		GenerateCA:       true,
+		CACertPath:       types.DefaultCaCertPath,
+		CAKeyPath:        types.DefaultCaKeyPath,
+		SkipVerify:       true, // Skip verifying upstream (httptest) cert
+		Payload: types.PayloadConfig{
+			RecordPayload:     true,
+			RecordPayloadHash: true,
+			MaxPayloadSize:    1024 * 1024,
+		},
+		EnableHTTPInspection: true,
+	}
+
+	networkAttestor := NewWithConfig(config)
+	log.SetLogger(log.ConsoleLogger{})
+
+	// Use --resolve so curl connects to "localhost" (which sends SNI in the TLS
+	// ClientHello) while actually hitting 127.0.0.1:<port>.  The proxy's MITM
+	// cert will be generated for "localhost" thanks to the SNI.
+	// --cacert trusts the proxy CA for the MITM cert.
+	curlCmd := fmt.Sprintf(
+		"curl -s --cacert %s --resolve localhost:%d:127.0.0.1 https://localhost:%d/",
+		types.DefaultCaCertPath, serverPort, serverPort,
+	)
+
+	cmd := commandrun.New(
+		commandrun.WithCommand([]string{"sh", "-c", curlCmd}),
+		commandrun.WithSilent(false),
+	)
+
+	ctx, err := attestation.NewContext("test-https", []attestation.Attestor{cmd, networkAttestor})
+	require.NoError(t, err)
+
+	err = ctx.RunAttestors()
+	require.NoError(t, err)
+
+	require.NotEmpty(t, networkAttestor.NetworkTrace.Connections, "Should record at least one connection")
+
+	found := false
+	for _, conn := range networkAttestor.NetworkTrace.Connections {
+		if conn.Destination.Port == uint16(serverPort) {
+			found = true
+			assert.True(t, conn.Intercepted, "Connection should be marked as intercepted")
+
+			// For HTTPS connections going through the HTTP proxy, the response
+			// body is captured in HTTPExchanges, not in TCPPayloads.
+			responseFound := false
+
+			// Check HTTPExchanges (populated by the HTTP proxy MITM path)
+			for _, exchange := range conn.HTTPExchanges {
+				if exchange.Response != nil &&
+					string(exchange.Response.Body.Data) == "Hello HTTPS" {
+					responseFound = true
+					break
+				}
+			}
+
+			// Also check TCPPayloads as fallback
+			if !responseFound {
+				for _, pl := range conn.TCPPayloads {
+					if string(pl.Payload.Data) == "Hello HTTPS" {
+						responseFound = true
+						break
+					}
+				}
+			}
+
+			assert.True(t, responseFound, "Should capture decrypted HTTPS response body")
+			break
+		}
+	}
+	assert.True(t, found, "Should find the connection to test server on port %d", serverPort)
+}
+
+// TestIntegrationRealWorldHTTPS downloads small metadata files from real package
+// registries (PyPI, Go module proxy, Maven Central) through the transparent MITM
+// proxy and verifies that connections are intercepted, decrypted, and recorded.
+//
+// This test requires:
+//   - root privileges (BPF)
+//   - internet access
+//
+// It is skipped automatically when either condition is not met.
+func TestIntegrationRealWorldHTTPS(t *testing.T) {
+	skipIfNotRoot(t)
+
+	// Quick connectivity check — skip if we can't reach the internet
+	dialConn, err := net.DialTimeout("tcp", "pypi.org:443", 3*time.Second)
+	if err != nil {
+		t.Skip("Skipping test: no internet connectivity")
+	}
+	dialConn.Close()
+
+	// Each sub-test downloads a small JSON/XML metadata file from a real registry.
+	tests := []struct {
+		name     string
+		host     string // hostname for SNI and assertions
+		url      string // full URL to fetch
+		contains string // substring expected in the response body
+	}{
+		{
+			name:     "PyPI",
+			host:     "pypi.org",
+			url:      "https://pypi.org/pypi/pip/json",
+			contains: "\"name\":\"pip\"",
+		},
+		{
+			name:     "GoProxy",
+			host:     "proxy.golang.org",
+			url:      "https://proxy.golang.org/golang.org/x/text/@v/list",
+			contains: "v0.",
+		},
+		{
+			name:     "MavenCentral",
+			host:     "repo1.maven.org",
+			url:      "https://repo1.maven.org/maven2/junit/junit/maven-metadata.xml",
+			contains: "<artifactId>junit</artifactId>",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := types.Config{
+				ObserveChildTree: true,
+				ProxyPort:        testProxyPort + 10 + uint16(i),
+				ProxyBindIPv4:    "127.0.0.1",
+				GenerateCA:       true,
+				CACertPath:       types.DefaultCaCertPath,
+				CAKeyPath:        types.DefaultCaKeyPath,
+				SkipVerify:       false, // real certs — no need to skip
+				Payload: types.PayloadConfig{
+					RecordPayload:     true,
+					RecordPayloadHash: true,
+					MaxPayloadSize:    1024 * 1024,
+				},
+				EnableHTTPInspection: true,
+			}
+
+			networkAttestor := NewWithConfig(config)
+			log.SetLogger(log.ConsoleLogger{})
+
+			curlCmd := fmt.Sprintf(
+				"curl -sS --cacert %s %s -o /dev/null -w '%%{http_code}'",
+				types.DefaultCaCertPath, tt.url,
+			)
+
+			cmd := commandrun.New(
+				commandrun.WithCommand([]string{"sh", "-c", curlCmd}),
+				commandrun.WithSilent(false),
+			)
+
+			ctx, err := attestation.NewContext(
+				fmt.Sprintf("test-real-%s", tt.name),
+				[]attestation.Attestor{cmd, networkAttestor},
+			)
+			require.NoError(t, err)
+
+			err = ctx.RunAttestors()
+			require.NoError(t, err)
+
+			require.NotEmpty(t, networkAttestor.NetworkTrace.Connections,
+				"Should record at least one connection")
+
+			// Find the connection to the expected host
+			found := false
+			for _, conn := range networkAttestor.NetworkTrace.Connections {
+				if conn.Destination.Hostname != tt.host {
+					continue
+				}
+				found = true
+
+				// Protocol should be https (intercepted via MITM)
+				assert.Equal(t, "https", conn.Protocol,
+					"Connection to %s should be https", tt.host)
+
+				// Must be intercepted
+				assert.True(t, conn.Intercepted,
+					"Connection to %s should be intercepted", tt.host)
+
+				// Destination port should be 443
+				assert.Equal(t, uint16(443), conn.Destination.Port,
+					"Connection to %s should target port 443", tt.host)
+
+				// TLS info should be present with ClientHello details
+				if assert.NotNil(t, conn.TLS, "TLS info should be present for %s", tt.host) {
+					if assert.NotNil(t, conn.TLS.ClientHello,
+						"ClientHello should be recorded for %s", tt.host) {
+						assert.NotEmpty(t, conn.TLS.ClientHello.SupportedVersions,
+							"ClientHello should list TLS versions for %s", tt.host)
+						assert.NotEmpty(t, conn.TLS.ClientHello.CipherSuites,
+							"ClientHello should list cipher suites for %s", tt.host)
+					}
+				}
+
+				// HTTP exchanges should be recorded
+				require.NotEmpty(t, conn.HTTPExchanges,
+					"Should have HTTP exchanges for %s", tt.host)
+
+				exchange := conn.HTTPExchanges[0]
+
+				// Request
+				assert.Equal(t, "GET", exchange.Request.Method,
+					"Request method should be GET for %s", tt.host)
+				assert.Contains(t, exchange.Request.URL, tt.host,
+					"Request URL should contain %s", tt.host)
+
+				// Response
+				if assert.NotNil(t, exchange.Response,
+					"Response should be present for %s", tt.host) {
+					assert.Equal(t, 200, exchange.Response.StatusCode,
+						"Response status for %s should be 200", tt.host)
+					assert.Greater(t, exchange.Response.Body.Size, int64(0),
+						"Response body for %s should not be empty", tt.host)
+
+					d := string(exchange.Response.Body.Data)
+					assert.Contains(t, string(d), tt.contains,
+						"Response body from %s should contain %q", tt.host, tt.contains)
+
+					// Payload hash should be recorded
+					assert.NotEmpty(t, exchange.Response.Body.Hash,
+						"Response body hash should be recorded for %s", tt.host)
+				}
+
+				// Bytes received should be > 0
+				assert.Greater(t, conn.BytesReceived, uint64(0),
+					"Should have received bytes from %s", tt.host)
+
+				break
+			}
+
+			assert.True(t, found,
+				"Should find an intercepted connection to %s", tt.host)
+		})
 	}
 }
 

--- a/attestation/networktrace/networktrace_test.go
+++ b/attestation/networktrace/networktrace_test.go
@@ -66,10 +66,10 @@ func TestNewWithConfig(t *testing.T) {
 
 	attestor := NewWithConfig(config)
 
-	assert.Equal(t, uint16(9999), attestor.config.ProxyPort)
-	assert.Equal(t, "127.0.0.1", attestor.config.ProxyBindIPv4)
-	assert.False(t, attestor.config.ObserveChildTree)
-	assert.True(t, attestor.config.Payload.RecordPayload)
+	assert.Equal(t, uint16(9999), attestor.NetworkTrace.Config.ProxyPort)
+	assert.Equal(t, "127.0.0.1", attestor.NetworkTrace.Config.ProxyBindIPv4)
+	assert.False(t, attestor.NetworkTrace.Config.ObserveChildTree)
+	assert.True(t, attestor.NetworkTrace.Config.Payload.RecordPayload)
 }
 
 func TestDefaultConfig(t *testing.T) {

--- a/attestation/networktrace/proxy/ca_manager.go
+++ b/attestation/networktrace/proxy/ca_manager.go
@@ -1,0 +1,241 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/in-toto/go-witness/log"
+)
+
+// CAManager loads or generates a CA certificate for TLS interception
+type CAManager struct {
+	caKey  any // Can be *rsa.PrivateKey or *ecdsa.PrivateKey
+	caCert *x509.Certificate
+}
+
+func NewCAManager(caKeyPath, caCertPath string, generate bool) (*CAManager, error) {
+	manager := &CAManager{}
+
+	if err := manager.loadOrGenerateCA(caKeyPath, caCertPath, generate); err != nil {
+		return nil, fmt.Errorf("load or generate CA: %w", err)
+	}
+
+	return manager, nil
+}
+
+func (cm *CAManager) loadOrGenerateCA(keyPath, certPath string, generate bool) error {
+	if _, err := os.Stat(keyPath); err == nil {
+		if _, err = os.Stat(certPath); err == nil {
+			if err = cm.loadCA(keyPath, certPath); err == nil {
+				log.Info("Loaded existing CA certificate")
+				return nil
+			} else {
+				log.Warnf("Failed to load existing CA (will regenerate if allowed): %v", err)
+			}
+		}
+	}
+
+	if !generate {
+		return fmt.Errorf("CA certificate or key not found, and generation is disabled")
+	}
+
+	log.Info("Generating new CA certificate (ECDSA P-256)")
+	if err := cm.generateCA(); err != nil {
+		return fmt.Errorf("generate CA: %w", err)
+	}
+
+	if err := cm.saveCA(keyPath, certPath); err != nil {
+		return fmt.Errorf("save CA: %w", err)
+	}
+
+	log.Infof("Saved CA certificate to %s (0644) and key to %s (0600)", certPath, keyPath)
+	return nil
+}
+
+func (cm *CAManager) loadCA(keyPath, certPath string) error {
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("read key file: %w", err)
+	}
+
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return fmt.Errorf("failed to decode PEM key")
+	}
+
+	var privateKey any
+
+	// Try PKCS#8 (Standard for modern keys)
+	if key, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes); err == nil {
+		privateKey = key
+	} else {
+		// Try PKCS#1 (Legacy RSA)
+		if key, err := x509.ParsePKCS1PrivateKey(keyBlock.Bytes); err == nil {
+			privateKey = key
+		} else {
+			// Try SEC1 (Legacy EC)
+			if key, err := x509.ParseECPrivateKey(keyBlock.Bytes); err == nil {
+				privateKey = key
+			} else {
+				return errors.New("failed to parse private key: format not recognized (tried PKCS#8, PKCS#1, SEC1)")
+			}
+		}
+	}
+
+	switch k := privateKey.(type) {
+	case *rsa.PrivateKey:
+		cm.caKey = k
+	case *ecdsa.PrivateKey:
+		cm.caKey = k
+	default:
+		return fmt.Errorf("unsupported key type: %T", privateKey)
+	}
+
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return fmt.Errorf("read cert file: %w", err)
+	}
+
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return fmt.Errorf("failed to decode PEM cert")
+	}
+
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse certificate: %w", err)
+	}
+
+	cm.caCert = cert
+	cm.caKey = privateKey
+
+	return nil
+}
+
+func (cm *CAManager) generateCA() error {
+	// Generate ECDSA key (Much faster than RSA for MITM signing)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("generate serial: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Witness Transparent Proxy CA"},
+			CommonName:   "Witness Proxy CA",
+		},
+		NotBefore: time.Now().Add(-1 * time.Hour),       // Backdate slightly to avoid clock skew
+		NotAfter:  time.Now().Add(365 * 24 * time.Hour), // 1 year validity
+
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		// BasicConstraintsValid=true and IsCA=true are CRITICAL for this to work as a CA
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("create certificate: %w", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return fmt.Errorf("parse generated certificate: %w", err)
+	}
+
+	cm.caKey = key
+	cm.caCert = cert
+
+	return nil
+}
+
+func (cm *CAManager) saveCA(keyPath, certPath string) error {
+	if err := os.MkdirAll(filepath.Dir(keyPath), 0755); err != nil {
+		return fmt.Errorf("create key directory: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(certPath), 0755); err != nil {
+		return fmt.Errorf("create cert directory: %w", err)
+	}
+
+	keyFile, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("create key file: %w", err)
+	}
+	defer keyFile.Close()
+
+	// Marshal to PKCS#8 (Handles both RSA and ECDSA generically)
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(cm.caKey)
+	if err != nil {
+		return fmt.Errorf("marshal private key: %w", err)
+	}
+
+	if err := pem.Encode(keyFile, &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}); err != nil {
+		return fmt.Errorf("write key pem: %w", err)
+	}
+
+	// Use 0644 so Snap/Curl/Other users can read the public cert
+	certFile, err := os.OpenFile(certPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("create cert file: %w", err)
+	}
+	defer certFile.Close()
+
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: cm.caCert.Raw}); err != nil {
+		return fmt.Errorf("write cert pem: %w", err)
+	}
+
+	// Just in case, ensuring permissions are correct
+	_ = os.Chmod(certPath, 0644)
+
+	return nil
+}
+
+// GetCA returns the CA certificate as a tls.Certificate
+func (cm *CAManager) GetCA() *tls.Certificate {
+	cert := tls.Certificate{
+		Certificate: [][]byte{cm.caCert.Raw},
+		PrivateKey:  cm.caKey,
+		Leaf:        cm.caCert,
+	}
+	return &cert
+}
+
+func (cm *CAManager) CertPEM() string {
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cm.caCert.Raw}))
+}

--- a/attestation/networktrace/proxy/http.go
+++ b/attestation/networktrace/proxy/http.go
@@ -1,0 +1,446 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/elazarl/goproxy"
+	"github.com/in-toto/go-witness/attestation/networktrace/bpf"
+	"github.com/in-toto/go-witness/attestation/networktrace/types"
+	"github.com/in-toto/go-witness/log"
+)
+
+// contextKey is a custom type for context keys to avoid collisions
+type contextKey string
+
+const metadataContextKey contextKey = "witness-connection-metadata"
+
+// SuppressConnectResponseWriter suppresses the "HTTP/1.1 200 Connection Established" response
+// that goproxy sends for CONNECT requests. In transparent mode, the client sends TLS ClientHello
+// and doesn't except an HTTP/1.0 200 OK response, so we need to eat that response.
+type SuppressConnectResponseWriter struct {
+	net.Conn
+	br *bufio.Reader // Existing buffered reader with peeked TLS data
+}
+
+// Header returns an empty header map
+func (e *SuppressConnectResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+// Read reads from the buffered reader to ensure peeked data is consumed first
+func (e *SuppressConnectResponseWriter) Read(p []byte) (int, error) {
+	n, err := e.br.Read(p)
+	return n, err
+}
+
+// // Write passes through the actual data (TLS handshake bytes) to the client
+// func (e *SuppressConnectResponseWriter) Write(data []byte) (int, error) {
+// 	// Only eat the CONNECT response, let everything else through
+// 	if bytes.Equal(data, []byte("HTTP/1.0 200 OK\r\n\r\n")) {
+// 		return len(data), nil // Suppress the HTTP OK response for transparent proxying
+// 	}
+// 	return e.Conn.Write(data)
+// }
+
+// Write passes through the actual data (TLS handshake bytes) to the client
+func (e *SuppressConnectResponseWriter) Write(data []byte) (int, error) {
+	// FIX: Use a more robust check.
+	// goproxy standard response is "HTTP/1.0 200 OK\r\n\r\n"
+	// But we should catch variations like HTTP/1.1 or partial writes.
+
+	// Check if it looks like an HTTP 200 OK response
+	if len(data) >= 12 && (bytes.HasPrefix(data, []byte("HTTP/1.0 200")) || bytes.HasPrefix(data, []byte("HTTP/1.1 200"))) {
+		log.Infof("[Suppressor] Successfully suppressed HTTP 200 OK response (%d bytes)", len(data))
+		return len(data), nil // Swallow the bytes, return success
+	}
+
+	// Debug log to catch if we are missing it
+	if len(data) < 100 && bytes.Contains(data, []byte("HTTP/")) {
+		log.Warnf("[Suppressor] WARNING: Leaking potential HTTP header to TLS client: %q", string(data))
+	}
+
+	return e.Conn.Write(data)
+}
+
+func (e *SuppressConnectResponseWriter) WriteHeader(statusCode int) {
+	// no-op
+}
+
+// Hijack implements http.Hijacker interface, required by goproxy for CONNECT requests
+func (e *SuppressConnectResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	// Reuse the existing buffered reader (br) which contains peeked data
+	return e, bufio.NewReadWriter(e.br, bufio.NewWriter(e)), nil
+}
+
+// HTTPProxy handles HTTP/HTTPS traffic using goproxy
+type HTTPProxy struct {
+	proxy *goproxy.ProxyHttpServer
+	caMgr *CAManager
+
+	connectionChan chan types.Connection
+	payloadConfig  types.PayloadConfig
+
+	// WaitGroup to track in-flight connection recordings
+	recordWg sync.WaitGroup
+}
+
+type goProxyUserData struct {
+	requestBody  []byte
+	connRecorder *ConnectionRecorder
+}
+
+// NewHTTPProxy creates a new HTTP/HTTPS proxy
+func NewHTTPProxy(caMgr *CAManager, payloadConfig types.PayloadConfig, connChan chan types.Connection, skipVerify bool) *HTTPProxy {
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Verbose = true
+
+	httpProxy := &HTTPProxy{
+		proxy:          proxy,
+		caMgr:          caMgr,
+		connectionChan: connChan,
+		payloadConfig:  payloadConfig,
+	}
+
+	httpProxy.setupHandlers(skipVerify)
+
+	return httpProxy
+}
+
+// Wait blocks until all in-flight HTTP recordings have completed
+func (h *HTTPProxy) Wait() {
+	h.recordWg.Wait()
+}
+
+// Serving self generated certificates for MITM
+func configureCert(ca *tls.Certificate) {
+	goproxy.OkConnect = &goproxy.ConnectAction{
+		Action: goproxy.ConnectAccept, TLSConfig: goproxy.TLSConfigFromCA(ca)}
+
+	goproxy.MitmConnect = &goproxy.ConnectAction{
+		Action: goproxy.ConnectMitm, TLSConfig: goproxy.TLSConfigFromCA(ca)}
+
+	goproxy.HTTPMitmConnect = &goproxy.ConnectAction{
+		Action: goproxy.ConnectHTTPMitm, TLSConfig: goproxy.TLSConfigFromCA(ca)}
+
+	goproxy.RejectConnect = &goproxy.ConnectAction{
+		Action: goproxy.ConnectReject, TLSConfig: goproxy.TLSConfigFromCA(ca)}
+}
+
+// setupHandlers configures the proxy handlers
+func (h *HTTPProxy) setupHandlers(skipVerify bool) {
+	h.proxy.Tr = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: skipVerify,
+		},
+
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	if h.caMgr != nil {
+		h.proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
+			log.Infof("Handling CONNECT request for host: %s", host)
+			// Extract metadata from request context and store in ProxyCtx for later use
+			if metadata, ok := ctx.Req.Context().Value(metadataContextKey).(*goProxyUserData); ok {
+				log.Infof("[Proxy] Found metadata in CONNECT context for %s", host)
+				ctx.UserData = metadata
+			} else {
+				log.Warnf("[Proxy] No metadata in CONNECT context for %s", host)
+			}
+			return goproxy.MitmConnect, host
+		})
+
+		configureCert(h.caMgr.GetCA())
+	}
+
+	h.proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		log.Infof("HTTP Request: %s %s %s", req.Method, req.Host, req.URL.Path)
+
+		// Try to get metadata from request context (set in HandleConnection)
+		// or from ctx.UserData as fallback
+		var metadata *goProxyUserData
+		if md, ok := req.Context().Value(metadataContextKey).(*goProxyUserData); ok {
+			metadata = md
+			// Store in UserData for response handler
+			ctx.UserData = metadata
+			log.Infof("[Proxy] Found metadata in Request context")
+		} else if ctx.UserData != nil {
+			if md, ok := ctx.UserData.(*goProxyUserData); ok {
+				metadata = md
+				log.Infof("[Proxy] Found metadata in ctx.UserData")
+			}
+		} else {
+			log.Warnf("[Proxy] No metadata found for request %s %s", req.Method, req.URL.Path)
+		}
+
+		if metadata != nil {
+			// Record the request body and pass it in context
+			if req.Body != nil {
+				bodyBytes, err := io.ReadAll(req.Body)
+				if err != nil {
+					log.Errorf("Read request body error: %v", err)
+				} else {
+					// create a copy of bodyBytes as NewBuffer will use the slice directly
+					bodyBytesCopy := make([]byte, len(bodyBytes))
+					copy(bodyBytesCopy, bodyBytes)
+
+					// Restore the io.ReadCloser to its original state
+					req.Body = io.NopCloser(bytes.NewBuffer(bodyBytesCopy))
+				}
+				// Add the body to the ctx.UserData
+				metadata.requestBody = bodyBytes
+			}
+
+		} else {
+			log.Errorf("metadata is nil, expected to be present")
+		}
+
+		return req, nil
+	})
+
+	h.proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+		if resp != nil {
+			log.Infof("HTTP Response: %s %d %s", resp.Request.Host, resp.StatusCode, resp.Status)
+
+			var goProxyData *goProxyUserData
+			if ctx.UserData != nil {
+				if md, ok := ctx.UserData.(*goProxyUserData); ok {
+					goProxyData = md
+				}
+			}
+
+			if goProxyData != nil {
+				// Read response body
+				var respBodyBytes []byte
+				if resp.Body != nil {
+					// TODO: Currently all is being buffered in the memory, implement some disk caching
+					// or io.TeeWriter for just calculating hash. Technically, proxy allows to record the
+					// entire payload, so that should be supported in case response is huge (iso, etc.)
+					bodyBytes, err := io.ReadAll(resp.Body)
+					if err != nil {
+						log.Errorf("Read response body error: %v", err)
+					} else {
+						respBodyBytes = make([]byte, len(bodyBytes))
+						copy(respBodyBytes, bodyBytes)
+						// Restore the io.ReadCloser to its original state
+						resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+					}
+				}
+
+				// cloning is required to prevent concurrent map read/write panic
+				requestHeader := cloneHeaders(ctx.Req.Header)
+				responseHeader := cloneHeaders(resp.Header)
+
+				// Record the exchange asynchronously
+				// Track with WaitGroup so we can wait for all recordings to complete
+				h.recordWg.Go(func() {
+					goProxyData.connRecorder.RecordHTTPExchange(ctx.Req, goProxyData.requestBody, resp, respBodyBytes, requestHeader, responseHeader)
+					result := goProxyData.connRecorder.Finish()
+					log.Infof("Recorded HTTP connection: %s", result.ID)
+					// Send the recorded connection to the channel
+					h.connectionChan <- result
+				})
+			} else {
+				log.Errorf("goProxyData or metadata is nil, expected to be present")
+			}
+		}
+		return resp
+	})
+}
+
+// HandleConnection handles an HTTP/HTTPS connection through goproxy
+func (h *HTTPProxy) HandleConnection(conn net.Conn, metadata *bpf.ConnectionMetadata) error {
+	// Create buffered reader for protocol detection
+	br := bufio.NewReader(conn)
+	return h.HandleBufferedConnection(conn, br, metadata)
+}
+
+// HandleBufferedConnection handles a connection with an existing buffered reader.
+// This allows the caller (e.g. TCPProxy) to peek at bytes for protocol detection
+// and then hand off the connection without losing buffered data.
+func (h *HTTPProxy) HandleBufferedConnection(conn net.Conn, br *bufio.Reader, metadata *bpf.ConnectionMetadata) error {
+	// Detect protocol (HTTP vs TLS)
+	proto, err := detectProtocol(br)
+	if err != nil {
+		return fmt.Errorf("detect protocol: %w", err)
+	}
+
+	switch proto {
+	case "tls":
+		// HTTPS traffic - parse SNI and create synthetic CONNECT request for goproxy to MITM this TCP connection
+		log.Infof("Detected TLS traffic: %s", metadata)
+		return h.handleTLS(conn, br, metadata)
+
+	case "http":
+		// Plain HTTP traffic - handle normally
+		log.Infof("Detected HTTP traffic: %s", metadata)
+		return h.handleHTTP(conn, br, metadata)
+
+	default:
+		return fmt.Errorf("unsupported protocol: %s", proto)
+	}
+}
+
+// handleTLS handles HTTPS traffic with transparent MITM
+func (h *HTTPProxy) handleTLS(conn net.Conn, br *bufio.Reader, metadata *bpf.ConnectionMetadata) error {
+	// Parse ClientHello from the existing buffered reader (includes SNI, versions, cipher suites)
+	parsedHello, err := parseClientHelloFromBufferedReader(br)
+	if err != nil {
+		log.Errorf("[TLS] Warning: Failed to parse ClientHello: %v", err)
+	}
+
+	var sni string
+	if parsedHello != nil {
+		sni = parsedHello.SNI
+	}
+
+	if sni == "" {
+		// No SNI - fall back to using IP:port
+		log.Errorf("[TLS] Warning: No SNI found, using IP address for CONNECT")
+		sni = metadata.OrigIP.String()
+	}
+
+	// Create synthetic CONNECT request for goproxy
+	target := fmt.Sprintf("%s:%d", sni, metadata.OrigPort)
+	connectReq := &http.Request{
+		Method: "CONNECT",
+		URL: &url.URL{
+			Host: target,
+		},
+		Host:       target,
+		Header:     make(http.Header),
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		RemoteAddr: conn.RemoteAddr().String(),
+	}
+
+	recorder := NewConnectionRecorder(metadata, "https", h.payloadConfig)
+	recorder.SetHostname(sni)
+	recorder.SetIntercepted(true)
+	// We need tls.ConnectionState to record actual negotiated parameters after handshake
+	// Needs exploring goproxy internals to get that info - for now, we skip it
+	// recorder.RecordTLSInfo(nil, sni)
+
+	// Record ClientHello info (what client supports/offers)
+	if parsedHello != nil && parsedHello.ClientHello != nil {
+		recorder.RecordClientHelloInfo(parsedHello.ClientHello)
+	}
+
+	goProxyUserData := &goProxyUserData{
+		connRecorder: recorder,
+	}
+
+	ctx := context.WithValue(context.Background(), metadataContextKey, goProxyUserData)
+	connectReq = connectReq.WithContext(ctx)
+
+	// Use EatConnectResponseWriter to suppress "HTTP/1.1 200" response
+	// Pass both the connection and the buffered reader so Hijack() can reuse it
+	writer := &SuppressConnectResponseWriter{
+		Conn: conn,
+		br:   br,
+	}
+
+	// Pass to goproxy - it will hijack the connection and spawn a goroutine for MITM
+	// We can return immediately - the connection ownership is transferred to goproxy
+	h.proxy.ServeHTTP(writer, connectReq)
+	return nil
+}
+
+// handleHTTP handles plain HTTP traffic
+func (h *HTTPProxy) handleHTTP(conn net.Conn, br *bufio.Reader, metadata *bpf.ConnectionMetadata) error {
+	transparentHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Since we are intercepting transparently, the request comes in as:
+		// GET /foo HTTP/1.1
+		// Host: example.com
+		//
+		// goproxy expects:
+		// GET http://example.com/foo HTTP/1.1
+
+		if r.URL.Scheme == "" {
+			r.URL.Scheme = "http" // Assume HTTP since we are in handleHTTP
+		}
+		if r.URL.Host == "" {
+			r.URL.Host = r.Host // Use the Host header
+		}
+
+		h.proxy.ServeHTTP(w, r)
+	})
+
+	server := &http.Server{
+		Handler: transparentHandler,
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			recorder := NewConnectionRecorder(metadata, "http", h.payloadConfig)
+			goProxyUserData := &goProxyUserData{
+				connRecorder: recorder,
+			}
+			return context.WithValue(ctx, metadataContextKey, goProxyUserData)
+		},
+	}
+
+	// Wrap connection with buffered reader
+	bufConn := &bufferedConn{Conn: conn, br: br}
+	err := server.Serve(&singleConnListener{conn: bufConn})
+
+	// server.Serve() returns io.EOF when the listener is closed (normal for single connection)
+	// or http.ErrServerClosed when explicitly closed - both are success cases
+	if err != nil && !errors.Is(err, http.ErrServerClosed) && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("serve HTTP connection: %w", err)
+	}
+
+	return nil
+}
+
+// singleConnListener is a net.Listener that returns a single connection then EOF
+type singleConnListener struct {
+	conn net.Conn
+	once sync.Once
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	var c net.Conn
+	l.once.Do(func() {
+		c = l.conn
+	})
+	if c != nil {
+		return c, nil
+	}
+	return nil, io.EOF
+}
+
+func (l *singleConnListener) Close() error {
+	return nil
+}
+
+func (l *singleConnListener) Addr() net.Addr {
+	return l.conn.LocalAddr()
+}

--- a/attestation/networktrace/proxy/http.go
+++ b/attestation/networktrace/proxy/http.go
@@ -294,6 +294,10 @@ func (h *HTTPProxy) HandleBufferedConnection(conn net.Conn, br *bufio.Reader, me
 		return fmt.Errorf("detect protocol: %w", err)
 	}
 
+	// TODO: There is a race condition between the TCP proxy terminating and the HTTP request, response pool draining
+	// This can be mitigated by adding a wait group here or some other better place. As we rely on goproxy package, it
+	// might be that we can't get that fine control, so hooking higher might be required. Also, making sure that we don't
+	// block indefinitely using a wg
 	switch proto {
 	case "tls":
 		// HTTPS traffic - parse SNI and create synthetic CONNECT request for goproxy to MITM this TCP connection

--- a/attestation/networktrace/proxy/recorder.go
+++ b/attestation/networktrace/proxy/recorder.go
@@ -17,7 +17,9 @@
 package proxy
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/in-toto/go-witness/attestation/networktrace/bpf"
@@ -84,6 +86,66 @@ func (r *ConnectionRecorder) RecordTCPPayloadDirect(direction Direction, data []
 	}
 }
 
+// RecordHTTPExchange records an HTTP request/response pair
+func (r *ConnectionRecorder) RecordHTTPExchange(req *http.Request, reqBody []byte, resp *http.Response, respBody []byte, reqHeaders http.Header, respHeaders http.Header) {
+	// TODO: Record not just the L7 req/resp bytes, but the L4 bytes as well (TLS handshake, headers, etc.)
+	exchange := types.HTTPExchange{
+		Timestamp: time.Now(),
+		Request: types.HTTPRequest{
+			Method:  req.Method,
+			URL:     req.URL.String(),
+			Host:    req.Host,
+			Headers: reqHeaders,
+			Body:    types.NewPayload(reqBody, r.config),
+		},
+	}
+
+	if resp != nil {
+		exchange.Response = &types.HTTPResponse{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Headers:    respHeaders,
+			Body:       types.NewPayload(respBody, r.config),
+		}
+	}
+
+	r.conn.HTTPExchanges = append(r.conn.HTTPExchanges, exchange)
+	r.conn.BytesSent += uint64(exchange.Request.Body.Size)
+	if exchange.Response != nil {
+		r.conn.BytesReceived += uint64(exchange.Response.Body.Size)
+	}
+}
+
+// RecordTLSInfo records TLS connection metadata
+func (r *ConnectionRecorder) RecordTLSInfo(state *tls.ConnectionState, sni string) {
+	r.conn.TLS = &types.TLSInfo{
+		SNI: sni,
+	}
+
+	if state != nil {
+		r.conn.TLS.Version = tlsVersionString(state.Version)
+		r.conn.TLS.CipherSuite = tls.CipherSuiteName(state.CipherSuite)
+	}
+}
+
+// RecordClientHelloInfo records ClientHello information parsed from the TLS handshake
+func (r *ConnectionRecorder) RecordClientHelloInfo(clientHello *types.ClientHelloInfo) {
+	if r.conn.TLS == nil {
+		r.conn.TLS = &types.TLSInfo{}
+	}
+	r.conn.TLS.ClientHello = clientHello
+}
+
+// SetHostname updates the destination hostname
+func (r *ConnectionRecorder) SetHostname(hostname string) {
+	r.conn.Destination.Hostname = hostname
+}
+
+// SetIntercepted marks the connection as fully intercepted
+func (r *ConnectionRecorder) SetIntercepted(intercepted bool) {
+	r.conn.Intercepted = intercepted
+}
+
 // SetProtocol updates the connection protocol
 func (r *ConnectionRecorder) SetProtocol(protocol string) {
 	r.conn.Protocol = protocol
@@ -101,4 +163,34 @@ func (r *ConnectionRecorder) Finish() types.Connection {
 	endTime := time.Now()
 	r.conn.EndTime = endTime
 	return r.conn
+}
+
+func cloneHeaders(h http.Header) map[string][]string {
+	if h == nil {
+		return nil
+	}
+
+	result := make(map[string][]string, len(h))
+	for k, v := range h {
+		vCopy := make([]string, len(v))
+		copy(vCopy, v)
+		result[k] = vCopy
+	}
+	return result
+}
+
+// tlsVersionString returns a human-readable TLS version string
+func tlsVersionString(version uint16) string {
+	switch version {
+	case tls.VersionTLS10:
+		return "TLS 1.0"
+	case tls.VersionTLS11:
+		return "TLS 1.1"
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	default:
+		return fmt.Sprintf("0x%04x", version)
+	}
 }

--- a/attestation/networktrace/proxy/tcp.go
+++ b/attestation/networktrace/proxy/tcp.go
@@ -17,6 +17,7 @@
 package proxy
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -35,8 +36,10 @@ import (
 // TCPProxy implements a transparent TCP proxy
 type TCPProxy struct {
 	maps          *bpf.Maps
+	httpProxy     *HTTPProxy
 	port          uint16
 	proxyBindIPv4 string
+	enableHTTP    bool
 	payloadConfig types.PayloadConfig
 
 	// Channel for collecting completed connections
@@ -58,11 +61,13 @@ type TCPConn struct {
 
 // NewTCPProxy creates a new transparent TCP proxy
 // The transparency comes from bpf which routes traffic to the proxy
-func NewTCPProxy(maps *bpf.Maps, port uint16, proxyBindIPv4 string, enableHTTP bool, payloadConfig types.PayloadConfig, connChan chan types.Connection) *TCPProxy {
+func NewTCPProxy(maps *bpf.Maps, httpProxy *HTTPProxy, port uint16, proxyBindIPv4 string, enableHTTP bool, payloadConfig types.PayloadConfig, connChan chan types.Connection) *TCPProxy {
 	return &TCPProxy{
 		maps:           maps,
+		httpProxy:      httpProxy,
 		port:           port,
 		proxyBindIPv4:  proxyBindIPv4,
+		enableHTTP:     httpProxy != nil && enableHTTP,
 		payloadConfig:  payloadConfig,
 		ConnectionChan: connChan,
 	}
@@ -216,7 +221,21 @@ func (p *TCPProxy) HandleConnection(ctx context.Context, clientConn net.Conn) er
 
 	log.Infof("New connection: %s (cookie=%d/0x%x)", metadata, sockCookie, sockCookie)
 
-	// This defer is placed here to allow easier addition of http proxy code later
+	// Try HTTP/HTTPS handling if enabled
+	if p.enableHTTP {
+		routed, wrappedConn, err := p.tryRouteToHTTPProxy(clientConn, metadata)
+		if err != nil {
+			log.Warnf("[TCP PROXY] HTTP proxy routing failed: %v", err)
+		}
+		if routed {
+			return nil
+		}
+		// Use the wrapped connection (preserves any peeked bytes)
+		if wrappedConn != nil {
+			clientConn = wrappedConn
+		}
+	}
+
 	defer clientConn.Close()
 
 	serverConn, err := p.connectToOriginalDestination(metadata)
@@ -298,6 +317,58 @@ func (p *TCPProxy) recordConnection(metadata *bpf.ConnectionMetadata, c2sData, s
 	log.Infof("Connection recorded: %s, sent=%d, received=%d", result.ID, result.BytesSent, result.BytesReceived)
 }
 
+// isWellKnownHTTPPort returns true for ports commonly used by HTTP/HTTPS
+func isWellKnownHTTPPort(port uint16) bool {
+	switch port {
+	case 80, 443, 8080, 8443:
+		return true
+	default:
+		return false
+	}
+}
+
+// tryRouteToHTTPProxy attempts to route the connection to the HTTP proxy.
+// For well-known HTTP/HTTPS ports it routes immediately (zero latency).
+// For other ports it peeks at the first bytes to detect TLS/HTTP protocol.
+// Returns (true, nil, nil) if the connection was handed off to the HTTP proxy.
+// Returns (false, wrappedConn, nil) if the connection should be handled as raw TCP.
+// wrappedConn preserves any bytes that were peeked during protocol detection.
+func (p *TCPProxy) tryRouteToHTTPProxy(clientConn net.Conn, metadata *bpf.ConnectionMetadata) (bool, net.Conn, error) {
+	// Fast path: well-known ports — route without peeking
+	if isWellKnownHTTPPort(metadata.OrigPort) {
+		log.Infof("[TCP PROXY] Well-known HTTP/S port %d, routing to HTTP proxy", metadata.OrigPort)
+		if err := p.httpProxy.HandleConnection(clientConn, metadata); err != nil {
+			return false, clientConn, fmt.Errorf("HTTP proxy: %w", err)
+		}
+		return true, nil, nil
+	}
+
+	// Slow path: peek to detect protocol on non-standard ports
+	br := bufio.NewReader(clientConn)
+	wrapped := &bufferedConn{Conn: clientConn, br: br}
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	_, peekErr := br.Peek(1)
+	_ = clientConn.SetReadDeadline(time.Time{})
+
+	if peekErr != nil {
+		// No data within timeout not HTTP/TLS (likely raw TCP)
+		return false, wrapped, nil
+	}
+
+	proto, err := detectProtocol(br)
+	if err != nil || (proto != "tls" && proto != "http") {
+		// Not a recognized protocol — fall back to raw TCP with preserved bytes
+		return false, wrapped, nil
+	}
+
+	log.Infof("[TCP PROXY] Detected %s protocol on port %d, routing to HTTP proxy", proto, metadata.OrigPort)
+	if err := p.httpProxy.HandleBufferedConnection(clientConn, br, metadata); err != nil {
+		return false, wrapped, fmt.Errorf("HTTP proxy (%s): %w", proto, err)
+	}
+	return true, nil, nil
+}
+
 func (p *TCPProxy) getConnectionMetadata(sockCookie uint64, isIPv6 bool) (*bpf.ConnectionMetadata, error) {
 	if isIPv6 {
 		metadata, err := p.maps.LookupOrigDstV6(sockCookie)
@@ -332,8 +403,8 @@ func (p *TCPProxy) bidirectionalCopy(_ context.Context, conn *TCPConn, clientToS
 	go func() {
 		_, err := io.Copy(io.MultiWriter(conn.ServerConn, clientToServerBuf), conn.ClientConn)
 
-		if tcpConn, ok := conn.ServerConn.(*net.TCPConn); ok {
-			_ = tcpConn.CloseWrite()
+		if tcpConn := underlyingTCPConn(conn.ServerConn); tcpConn != nil {
+			_ = tcpConn.CloseWrite() // Send a FIN to the server to signal that the client is done sending data
 		}
 		errChan <- err
 	}()
@@ -342,8 +413,8 @@ func (p *TCPProxy) bidirectionalCopy(_ context.Context, conn *TCPConn, clientToS
 	go func() {
 		_, err := io.Copy(io.MultiWriter(conn.ClientConn, serverToClientBuf), conn.ServerConn)
 
-		if tcpConn, ok := conn.ClientConn.(*net.TCPConn); ok {
-			_ = tcpConn.CloseWrite()
+		if tcpConn := underlyingTCPConn(conn.ClientConn); tcpConn != nil {
+			_ = tcpConn.CloseWrite() // Send a FIN to the client to signal that the server is done sending data
 		}
 		errChan <- err
 	}()
@@ -358,4 +429,28 @@ func (p *TCPProxy) bidirectionalCopy(_ context.Context, conn *TCPConn, clientToS
 		return err2
 	}
 	return nil
+}
+
+// bufferedConn wraps a net.Conn with a bufio.Reader so that
+// any data already peeked/buffered is consumed before reading
+// from the underlying connection.
+type bufferedConn struct {
+	net.Conn
+	br *bufio.Reader
+}
+
+func (b *bufferedConn) Read(p []byte) (int, error) {
+	return b.br.Read(p)
+}
+
+// underlyingTCPConn unwraps wrapper types to find the underlying *net.TCPConn.
+func underlyingTCPConn(c net.Conn) *net.TCPConn {
+	switch v := c.(type) {
+	case *net.TCPConn:
+		return v
+	case *bufferedConn:
+		return underlyingTCPConn(v.Conn)
+	default:
+		return nil
+	}
 }

--- a/attestation/networktrace/proxy/tcp.go
+++ b/attestation/networktrace/proxy/tcp.go
@@ -167,6 +167,9 @@ func (p *TCPProxy) Start(ctx context.Context, ready chan<- struct{}) error {
 	// Wait for all in-flight connection recordings to complete
 	// This ensures all sends to ConnectionChan are done before we return
 	p.recordWg.Wait()
+	if p.enableHTTP {
+		p.httpProxy.Wait()
+	}
 
 	log.Infof("TCP proxy shutdown complete: all recordings finished")
 

--- a/attestation/networktrace/proxy/tls_utils.go
+++ b/attestation/networktrace/proxy/tls_utils.go
@@ -1,0 +1,267 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package proxy
+
+import (
+	"bufio"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/in-toto/go-witness/attestation/networktrace/types"
+)
+
+// Protocol detection and TLS utilities for transparent HTTPS proxying
+
+// detectProtocol peeks at connection bytes to determine protocol
+func detectProtocol(br *bufio.Reader) (string, error) {
+	// Peek at the first 24 bytes (enough for TLS, HTTP detection)
+	header, err := br.Peek(24)
+	if err != nil && !errors.Is(err, bufio.ErrBufferFull) && err != io.EOF {
+		return "", fmt.Errorf("peek connection: %w", err)
+	}
+
+	if len(header) < 5 {
+		return "unknown", nil
+	}
+
+	// Check for TLS: ContentType (0x16=Handshake) + Version (0x03 0x00-0x03)
+	if header[0] == 0x16 && header[1] == 0x03 &&
+		(header[2] == 0x00 || header[2] == 0x01 || header[2] == 0x02 || header[2] == 0x03) {
+		return "tls", nil
+	}
+
+	// Check for HTTP methods
+	headerStr := string(header)
+	methods := []string{"GET ", "POST", "PUT ", "HEAD", "DELE", "OPTI", "PATC", "TRAC", "CONN"}
+	for _, method := range methods {
+		if len(headerStr) >= len(method) && headerStr[:len(method)] == method {
+			return "http", nil
+		}
+	}
+
+	// TODO: Verify support for HTTP/2 detection if needed
+
+	return "unknown", nil
+}
+
+// parseSNIExtension parses the SNI extension data
+func parseSNIExtension(data []byte) (string, error) {
+	// SNI Extension format:
+	// [0-1]  Server Name List Length
+	// [2]    Server Name Type (0 = host_name)
+	// [3-4]  Server Name Length
+	// [5...] Server Name
+
+	if len(data) < 5 {
+		return "", fmt.Errorf("SNI extension too short")
+	}
+
+	listLen := int(binary.BigEndian.Uint16(data[0:2]))
+	if listLen+2 > len(data) {
+		return "", fmt.Errorf("invalid SNI list length")
+	}
+
+	pos := 2
+	nameType := data[pos]
+	if nameType != 0x00 { // Not host_name
+		return "", fmt.Errorf("unsupported SNI name type: 0x%x", nameType)
+	}
+
+	pos++
+	nameLen := int(binary.BigEndian.Uint16(data[pos : pos+2]))
+	pos += 2
+
+	if pos+nameLen > len(data) {
+		return "", fmt.Errorf("invalid SNI name length")
+	}
+
+	hostname := string(data[pos : pos+nameLen])
+	return hostname, nil
+}
+
+// ParsedClientHello contains parsed ClientHello information
+type ParsedClientHello struct {
+	SNI           string
+	ClientHello   *types.ClientHelloInfo
+	LegacyVersion uint16 // Legacy version field from ClientHello
+}
+
+// parseClientHelloFromBufferedReader parses ClientHello from an existing buffered reader by peeking
+// This preserves all data in the buffer for subsequent reads
+// Returns SNI and full ClientHelloInfo including supported versions and cipher suites
+func parseClientHelloFromBufferedReader(br *bufio.Reader) (*ParsedClientHello, error) {
+	// Peek at TLS record to get length
+	recordHeader, err := br.Peek(5)
+	if err != nil {
+		return nil, fmt.Errorf("peek record header: %w", err)
+	}
+
+	if recordHeader[0] != 0x16 {
+		return nil, fmt.Errorf("not a TLS handshake")
+	}
+
+	recordLength := int(binary.BigEndian.Uint16(recordHeader[3:5]))
+	totalLength := 5 + recordLength
+
+	// Peek the entire TLS record (without consuming it)
+	fullRecord, err := br.Peek(totalLength)
+	if err != nil {
+		return nil, fmt.Errorf("peek full record: %w", err)
+	}
+
+	// Parse ClientHello from the peeked data
+	handshake := fullRecord[5:] // Skip record header
+
+	if len(handshake) < 39 || handshake[0] != 0x01 {
+		return nil, fmt.Errorf("invalid ClientHello")
+	}
+
+	result := &ParsedClientHello{
+		ClientHello: &types.ClientHelloInfo{},
+	}
+
+	// Extract legacy version (bytes 4-5 of handshake, after msg type and length)
+	result.LegacyVersion = binary.BigEndian.Uint16(handshake[4:6])
+
+	// Parse to find extensions and cipher suites
+	pos := 38
+	sessionIDLen := int(handshake[pos])
+	pos += 1 + sessionIDLen
+
+	if pos+2 > len(handshake) {
+		return nil, fmt.Errorf("invalid ClientHello")
+	}
+
+	// Parse cipher suites
+	cipherSuitesLen := int(binary.BigEndian.Uint16(handshake[pos : pos+2]))
+	pos += 2
+
+	if pos+cipherSuitesLen > len(handshake) {
+		return nil, fmt.Errorf("invalid cipher suites length")
+	}
+
+	// Extract cipher suites (each is 2 bytes)
+	cipherSuitesData := handshake[pos : pos+cipherSuitesLen]
+	for i := 0; i+1 < len(cipherSuitesData); i += 2 {
+		suiteID := binary.BigEndian.Uint16(cipherSuitesData[i : i+2])
+		result.ClientHello.CipherSuites = append(result.ClientHello.CipherSuites, fmt.Sprintf("0x%04x", suiteID))
+		// Try to get human-readable name
+		if name := tls.CipherSuiteName(suiteID); name != "" && name != fmt.Sprintf("0x%04X", suiteID) {
+			result.ClientHello.CipherSuiteNames = append(result.ClientHello.CipherSuiteNames, name)
+		}
+	}
+
+	pos += cipherSuitesLen
+
+	if pos+1 > len(handshake) {
+		return nil, fmt.Errorf("invalid ClientHello")
+	}
+
+	compressionMethodsLen := int(handshake[pos])
+	pos += 1 + compressionMethodsLen
+
+	if pos+2 > len(handshake) {
+		// No extensions, use legacy version
+		result.ClientHello.SupportedVersions = []string{tlsVersionToString(result.LegacyVersion)}
+		return result, nil
+	}
+
+	extensionsLen := int(binary.BigEndian.Uint16(handshake[pos : pos+2]))
+	pos += 2
+
+	extensionsEnd := pos + extensionsLen
+	if extensionsEnd > len(handshake) {
+		return nil, fmt.Errorf("invalid extensions")
+	}
+
+	// Parse extensions
+	var foundSupportedVersions bool
+	for pos+4 <= extensionsEnd {
+		extensionType := binary.BigEndian.Uint16(handshake[pos : pos+2])
+		extensionLen := int(binary.BigEndian.Uint16(handshake[pos+2 : pos+4]))
+		pos += 4
+
+		if pos+extensionLen > len(handshake) {
+			return nil, fmt.Errorf("invalid extension")
+		}
+
+		extensionData := handshake[pos : pos+extensionLen]
+
+		switch extensionType {
+		case 0x0000: // SNI
+			sni, err := parseSNIExtension(extensionData)
+			if err == nil {
+				result.SNI = sni
+			}
+		case 0x002b: // supported_versions (43)
+			versions := parseSupportedVersionsExtension(extensionData)
+			if len(versions) > 0 {
+				result.ClientHello.SupportedVersions = versions
+				foundSupportedVersions = true
+			}
+		}
+
+		pos += extensionLen
+	}
+
+	// If no supported_versions extension, use legacy version
+	if !foundSupportedVersions {
+		result.ClientHello.SupportedVersions = []string{tlsVersionToString(result.LegacyVersion)}
+	}
+
+	return result, nil
+}
+
+// parseSupportedVersionsExtension parses the supported_versions extension from ClientHello
+func parseSupportedVersionsExtension(data []byte) []string {
+	if len(data) < 1 {
+		return nil
+	}
+
+	// In ClientHello, format is: length (1 byte) + list of versions (2 bytes each)
+	listLen := int(data[0])
+	if listLen+1 > len(data) {
+		return nil
+	}
+
+	var versions []string
+	for i := 1; i+1 <= listLen+1 && i+1 < len(data); i += 2 {
+		version := binary.BigEndian.Uint16(data[i : i+2])
+		versions = append(versions, tlsVersionToString(version))
+	}
+
+	return versions
+}
+
+// tlsVersionToString converts a TLS version number to a human-readable string
+func tlsVersionToString(version uint16) string {
+	switch version {
+	case tls.VersionTLS10:
+		return "TLS 1.0"
+	case tls.VersionTLS11:
+		return "TLS 1.1"
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	default:
+		return fmt.Sprintf("0x%04x", version)
+	}
+}

--- a/attestation/networktrace/types/config.go
+++ b/attestation/networktrace/types/config.go
@@ -17,6 +17,8 @@
 package types
 
 const (
+	DefaultCaCertPath    = "./witness_nettrace_proxy/ca_cert.pem"
+	DefaultCaKeyPath     = "./witness_nettrace_proxy/ca_key.pem"
 	DefaultProxyPort     = 8888
 	DefaultProxyBindIPv4 = "127.0.0.1"
 )
@@ -33,6 +35,14 @@ type Config struct {
 	ProxyPort     uint16 `json:"proxy_port"`
 	ProxyBindIPv4 string `json:"proxy_bind_ipv4"`
 
+	EnableHTTPInspection bool `json:"enabled_http_inspection"`
+
+	// TLS/Certificate configuration for HTTPS interception
+	GenerateCA bool   `json:"generate_ca"`
+	CACertPath string `json:"ca_cert_path,omitempty"`
+	CAKeyPath  string `json:"ca_key_path,omitempty"`
+	SkipVerify bool   `json:"skip_verify"`
+
 	// Payload recording options
 	Payload PayloadConfig `json:"payload"`
 }
@@ -40,9 +50,13 @@ type Config struct {
 // DefaultConfig returns a Config with sensible defaults
 func DefaultConfig() Config {
 	return Config{
-		ProxyPort:        DefaultProxyPort,
-		ProxyBindIPv4:    DefaultProxyBindIPv4,
-		ObserveChildTree: true,
-		Payload:          DefaultPayloadConfig(),
+		ProxyPort:            DefaultProxyPort,
+		ProxyBindIPv4:        DefaultProxyBindIPv4,
+		GenerateCA:           true,
+		CACertPath:           DefaultCaCertPath,
+		CAKeyPath:            DefaultCaKeyPath,
+		ObserveChildTree:     true,
+		EnableHTTPInspection: true,
+		Payload:              DefaultPayloadConfig(),
 	}
 }

--- a/attestation/networktrace/types/config.go
+++ b/attestation/networktrace/types/config.go
@@ -57,6 +57,9 @@ func DefaultConfig() Config {
 		CAKeyPath:            DefaultCaKeyPath,
 		ObserveChildTree:     true,
 		EnableHTTPInspection: true,
+		ObservePIDs:          make([]uint32, 0),
+		ObserveCgroups:       make([]string, 0),
+		ObserveCommands:      make([]string, 0),
 		Payload:              DefaultPayloadConfig(),
 	}
 }

--- a/attestation/networktrace/types/types.go
+++ b/attestation/networktrace/types/types.go
@@ -30,7 +30,7 @@ type PayloadConfig struct {
 	// RecordPayloadHash enables storing SHA256 hash of payload (default: true)
 	RecordPayloadHash bool `json:"record_payload_hash"`
 	// MaxPayloadSize is the maximum size in bytes to store raw payload
-	// If payload exceeds this, it will be truncated
+	// If payload size exceeds, it's truncated
 	// Set to 0 for unlimited (default: 1MB)
 	MaxPayloadSize int64 `json:"max_payload_size"`
 }
@@ -58,11 +58,31 @@ type Endpoint struct {
 	Hostname string `json:"hostname,omitempty"` // From SNI or Host header
 }
 
+// TLSInfo contains TLS/SSL connection metadata
+type TLSInfo struct {
+	SNI         string `json:"sni,omitempty"`
+	Version     string `json:"version,omitempty"`
+	CipherSuite string `json:"cipher_suite,omitempty"`
+
+	// ClientHello captures what the client offered/supports (parsed from ClientHello)
+	ClientHello *ClientHelloInfo `json:"client_hello,omitempty"`
+}
+
+// ClientHelloInfo contains TLS ClientHello information parsed from the raw handshake
+type ClientHelloInfo struct {
+	// SupportedVersions lists TLS versions the client supports (from supported_versions extension or legacy)
+	SupportedVersions []string `json:"supported_versions,omitempty"`
+	// CipherSuites lists cipher suites the client offered (as hex codes)
+	CipherSuites []string `json:"cipher_suites,omitempty"`
+	// CipherSuiteNames lists cipher suite names (where known)
+	CipherSuiteNames []string `json:"cipher_suite_names,omitempty"`
+}
+
 // Payload represents recorded data with configurable storage options
 type Payload struct {
 	// Size is always recorded (bytes)
 	Size int64 `json:"size"`
-	// Data contains the raw payload (if RecordPayload=true and size <= MaxPayloadSize)
+	// Data contains the raw payload (get's truncated if greater than PayloadConfig.MaxPayloadSize)
 	Data []byte `json:"data,omitempty"`
 	// Hash contains SHA256 hash of payload (if RecordPayloadHash=true)
 	Hash string `json:"hash,omitempty"`
@@ -103,6 +123,30 @@ func NewPayload(data []byte, config PayloadConfig) Payload {
 	return p
 }
 
+// HTTPRequest records an HTTP request
+type HTTPRequest struct {
+	Method  string              `json:"method"`
+	URL     string              `json:"url"`
+	Host    string              `json:"host"`
+	Headers map[string][]string `json:"headers,omitempty"`
+	Body    Payload             `json:"body"`
+}
+
+// HTTPResponse records an HTTP response
+type HTTPResponse struct {
+	StatusCode int                 `json:"status_code"`
+	Status     string              `json:"status"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	Body       Payload             `json:"body"`
+}
+
+// HTTPExchange represents a complete HTTP request/response pair
+type HTTPExchange struct {
+	Timestamp time.Time     `json:"timestamp"`
+	Request   HTTPRequest   `json:"request"`
+	Response  *HTTPResponse `json:"response,omitempty"` // nil if no response received
+}
+
 // TCPPayload represents raw TCP payload for non-HTTP connections
 type TCPPayload struct {
 	Timestamp time.Time `json:"timestamp"`
@@ -127,22 +171,32 @@ type Connection struct {
 
 	// Network endpoints
 	// TODO: Update bpf maps to store source endpoint as well
-	// Source      Endpoint `json:"source"`
+	Source      Endpoint `json:"source"`
 	Destination Endpoint `json:"destination"`
 
-	// Raw TCP payloads
+	// TLS metadata (only for HTTPS/TLS connections)
+	TLS *TLSInfo `json:"tls,omitempty"`
+
+	// HTTP exchanges (for HTTP/HTTPS when intercepted)
+	HTTPExchanges []HTTPExchange `json:"http_exchanges,omitempty"`
+
+	// Raw TCP payloads (for non-HTTP TCP when payload recording enabled)
 	TCPPayloads []TCPPayload `json:"tcp_payloads,omitempty"`
 
 	// Traffic statistics
 	BytesSent     uint64 `json:"bytes_sent"`
 	BytesReceived uint64 `json:"bytes_received"`
 
-	Error string `json:"error,omitempty"`
+	// Observation metadata
+	Intercepted bool   `json:"intercepted"` // True if full inspection (MITM for TLS)
+	Error       string `json:"error,omitempty"`
 }
 
 // NetworkSummary provides aggregated statistics for quick policy evaluation
 type NetworkSummary struct {
 	TotalConnections   int            `json:"total_connections"`
+	InterceptedCount   int            `json:"intercepted_count"`
+	MetadataOnlyCount  int            `json:"metadata_only_count"`
 	ProtocolCounts     map[string]int `json:"protocol_counts"`
 	UniqueHosts        []string       `json:"unique_hosts"`
 	UniqueIPs          []string       `json:"unique_ips"`
@@ -164,6 +218,13 @@ func ComputeSummary(connections []Connection) NetworkSummary {
 		// Count protocols
 		summary.ProtocolCounts[conn.Protocol]++
 
+		// Count intercepted vs metadata-only
+		if conn.Intercepted {
+			summary.InterceptedCount++
+		} else {
+			summary.MetadataOnlyCount++
+		}
+
 		// Aggregate bytes
 		summary.TotalBytesSent += conn.BytesSent
 		summary.TotalBytesReceived += conn.BytesReceived
@@ -177,6 +238,7 @@ func ComputeSummary(connections []Connection) NetworkSummary {
 		}
 	}
 
+	// Convert sets to slices
 	for host := range hostSet {
 		summary.UniqueHosts = append(summary.UniqueHosts, host)
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea
 	github.com/edwarnicke/gitoid v0.0.0-20220710194850-1be5bfda1f9d
+	github.com/elazarl/goproxy v1.7.2
 	github.com/fkautz/omnitrail-go v0.0.0-20240613153526-999f2e7d0fc9
 	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/go-git/go-git/v5 v5.19.1

--- a/registry/option.go
+++ b/registry/option.go
@@ -26,7 +26,7 @@ type Configurer interface {
 }
 
 type Option interface {
-	int | string | []string | bool | time.Duration | *string
+	int | int64 | string | []string | []int | bool | time.Duration | *string
 }
 
 type ConfigOption[T any, TOption Option] struct {
@@ -108,6 +108,24 @@ func DurationConfigOption[T any](name, description string, defaultVal time.Durat
 
 func StringPtrConfigOption[T any](name, description string, defaultVal *string, setter func(T, *string) (T, error)) *ConfigOption[T, *string] {
 	return &ConfigOption[T, *string]{
+		name:        name,
+		description: description,
+		defaultVal:  defaultVal,
+		setter:      setter,
+	}
+}
+
+func Int64ConfigOption[T any](name, description string, defaultVal int64, setter func(T, int64) (T, error)) *ConfigOption[T, int64] {
+	return &ConfigOption[T, int64]{
+		name:        name,
+		description: description,
+		defaultVal:  defaultVal,
+		setter:      setter,
+	}
+}
+
+func IntSliceConfigOption[T any](name, description string, defaultVal []int, setter func(T, []int) (T, error)) *ConfigOption[T, []int] {
+	return &ConfigOption[T, []int]{
 		name:        name,
 		description: description,
 		defaultVal:  defaultVal,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -120,9 +120,13 @@ func (r Registry[T]) SetDefaultVals(entity T, opts []Configurer) (T, error) {
 		switch o := opt.(type) {
 		case *ConfigOption[T, int]:
 			entity, err = o.Setter()(entity, o.DefaultVal())
+		case *ConfigOption[T, int64]:
+			entity, err = o.Setter()(entity, o.DefaultVal())
 		case *ConfigOption[T, string]:
 			entity, err = o.Setter()(entity, o.DefaultVal())
 		case *ConfigOption[T, []string]:
+			entity, err = o.Setter()(entity, o.DefaultVal())
+		case *ConfigOption[T, []int]:
 			entity, err = o.Setter()(entity, o.DefaultVal())
 		case *ConfigOption[T, bool]:
 			entity, err = o.Setter()(entity, o.DefaultVal())

--- a/schemagen/network-trace.json
+++ b/schemagen/network-trace.json
@@ -3,6 +3,30 @@
   "$id": "https://github.com/in-toto/go-witness/attestation/networktrace/network-trace",
   "$ref": "#/$defs/NetworkTrace",
   "$defs": {
+    "ClientHelloInfo": {
+      "properties": {
+        "supported_versions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cipher_suites": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "cipher_suite_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Config": {
       "properties": {
         "observe_pids": {
@@ -32,6 +56,21 @@
         "proxy_bind_ipv4": {
           "type": "string"
         },
+        "enabled_http_inspection": {
+          "type": "boolean"
+        },
+        "generate_ca": {
+          "type": "boolean"
+        },
+        "ca_cert_path": {
+          "type": "string"
+        },
+        "ca_key_path": {
+          "type": "string"
+        },
+        "skip_verify": {
+          "type": "boolean"
+        },
         "payload": {
           "$ref": "#/$defs/PayloadConfig"
         }
@@ -42,6 +81,9 @@
         "observe_child_tree",
         "proxy_port",
         "proxy_bind_ipv4",
+        "enabled_http_inspection",
+        "generate_ca",
+        "skip_verify",
         "payload"
       ]
     },
@@ -64,8 +106,20 @@
         "process": {
           "$ref": "#/$defs/ProcessInfo"
         },
+        "source": {
+          "$ref": "#/$defs/Endpoint"
+        },
         "destination": {
           "$ref": "#/$defs/Endpoint"
+        },
+        "tls": {
+          "$ref": "#/$defs/TLSInfo"
+        },
+        "http_exchanges": {
+          "items": {
+            "$ref": "#/$defs/HTTPExchange"
+          },
+          "type": "array"
         },
         "tcp_payloads": {
           "items": {
@@ -79,6 +133,9 @@
         "bytes_received": {
           "type": "integer"
         },
+        "intercepted": {
+          "type": "boolean"
+        },
         "error": {
           "type": "string"
         }
@@ -90,9 +147,11 @@
         "protocol",
         "start_time",
         "process",
+        "source",
         "destination",
         "bytes_sent",
-        "bytes_received"
+        "bytes_received",
+        "intercepted"
       ]
     },
     "Endpoint": {
@@ -115,9 +174,97 @@
         "port"
       ]
     },
+    "HTTPExchange": {
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "request": {
+          "$ref": "#/$defs/HTTPRequest"
+        },
+        "response": {
+          "$ref": "#/$defs/HTTPResponse"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "timestamp",
+        "request"
+      ]
+    },
+    "HTTPRequest": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "body": {
+          "$ref": "#/$defs/Payload"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "method",
+        "url",
+        "host",
+        "body"
+      ]
+    },
+    "HTTPResponse": {
+      "properties": {
+        "status_code": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "body": {
+          "$ref": "#/$defs/Payload"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status_code",
+        "status",
+        "body"
+      ]
+    },
     "NetworkSummary": {
       "properties": {
         "total_connections": {
+          "type": "integer"
+        },
+        "intercepted_count": {
+          "type": "integer"
+        },
+        "metadata_only_count": {
           "type": "integer"
         },
         "protocol_counts": {
@@ -149,6 +296,8 @@
       "type": "object",
       "required": [
         "total_connections",
+        "intercepted_count",
+        "metadata_only_count",
         "protocol_counts",
         "unique_hosts",
         "unique_ips",
@@ -177,6 +326,9 @@
         },
         "config": {
           "$ref": "#/$defs/Config"
+        },
+        "ca_cert_pem": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -270,6 +422,24 @@
         "direction",
         "payload"
       ]
+    },
+    "TLSInfo": {
+      "properties": {
+        "sni": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "cipher_suite": {
+          "type": "string"
+        },
+        "client_hello": {
+          "$ref": "#/$defs/ClientHelloInfo"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it

Adds HTTP MITM proxy support for `networktrace` attestor and also exposes the config options through the registry. 

## Which issue(s) this PR fixes (optional)

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
