### PR TITLE
fix(environment): skip malformed glob patterns to avoid nil-glob panic

### DIFF
--- a/environment/environment_test.go
+++ b/environment/environment_test.go
@@ -170,6 +170,49 @@ func TestCapture_Capture(t *testing.T) {
 				"TEST_TEXT": "value",
 			},
 		},
+		{
+			// A malformed glob (unterminated character class) used to panic
+			// because the failed compile result was still appended to the
+			// match list and later dereferenced. It should now be skipped.
+			name: "Obfuscate with malformed glob does not panic",
+			fields: fields{
+				sensitiveVarsList: DefaultSensitiveEnvList(),
+				addSensitiveVarsList: map[string]struct{}{
+					"*[": {},
+				},
+				excludeSensitiveVarsList:    map[string]struct{}{},
+				filterVarsEnabled:           false,
+				disableSensitiveVarsDefault: true,
+			},
+			args: args{
+				env: []string{
+					"TEST_TEXT=value",
+				},
+			},
+			want: map[string]string{
+				"TEST_TEXT": "value",
+			},
+		},
+		{
+			name: "Filter with malformed glob does not panic",
+			fields: fields{
+				sensitiveVarsList: DefaultSensitiveEnvList(),
+				addSensitiveVarsList: map[string]struct{}{
+					"*[": {},
+				},
+				excludeSensitiveVarsList:    map[string]struct{}{},
+				filterVarsEnabled:           true,
+				disableSensitiveVarsDefault: true,
+			},
+			args: args{
+				env: []string{
+					"TEST_TEXT=value",
+				},
+			},
+			want: map[string]string{
+				"TEST_TEXT": "value",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/environment/filter.go
+++ b/environment/filter.go
@@ -30,7 +30,8 @@ func FilterEnvironmentArray(variables []string, blockList map[string]struct{}, e
 		if strings.Contains(k, "*") {
 			filterGlobCompiled, err := glob.Compile(k)
 			if err != nil {
-				log.Errorf("obfuscate glob pattern could not be interpreted: %w", err)
+				log.Errorf("filter glob pattern could not be interpreted: %w", err)
+				continue
 			}
 
 			filterGlobList = append(filterGlobList, filterGlobCompiled)

--- a/environment/obfuscate.go
+++ b/environment/obfuscate.go
@@ -31,6 +31,7 @@ func ObfuscateEnvironmentArray(variables []string, obfuscateList map[string]stru
 			obfuscateGlobCompiled, err := glob.Compile(k)
 			if err != nil {
 				log.Errorf("obfuscate glob pattern could not be interpreted: %w", err)
+				continue
 			}
 
 			obfuscateGlobList = append(obfuscateGlobList, obfuscateGlobCompiled)


### PR DESCRIPTION
## What this PR does / why we need it

The environment attestor runs by default during `witness run`, and a malformed glob in a sensitive-key entry (say `*[`) crashes the whole attestation with a nil pointer dereference, so you lose all output.

Both ObfuscateEnvironmentArray and FilterEnvironmentArray compile a list of globs. When glob.Compile errors, the code logs it but still appends the nil compiled glob, and the later glob.Match(key) panics on it:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/in-toto/go-witness/environment.ObfuscateEnvironmentArray(...)
	environment/obfuscate.go:49
```

This is reachable from the public WithAdditionalKeys option and the `--attestor-environment-add-sensitive-key` CLI flag, so one bad user value brings down the run. I added a `continue` in the compile-error branch of both functions so an invalid pattern is logged and skipped and the nil glob is never stored. While there I fixed the filter.go log message, which still said "obfuscate glob pattern" (copy-paste from obfuscate.go).

## Verification

Added table cases to TestCapture_Capture for a malformed glob in both the obfuscate and filter paths; both panic on current code and pass here. `go test ./environment/...` passes, vet and gofmt clean.

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [x] All workflow checks passing (automatically enforced)
- [x] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**: Minimal change, one `continue` per function plus the log fix. Happy to tweak the wording or tests. Thanks!
