### PR TITLE
fix(tracing): properly cleanup ENOENT files for child processes

### DIFF
--- a/attestation/commandrun/tracing_linux.go
+++ b/attestation/commandrun/tracing_linux.go
@@ -498,4 +498,3 @@ func getSpecBypassIsVulnFromStatus(status []byte) bool {
 
 	return false
 }
-

--- a/attestation/commandrun/tracing_linux.go
+++ b/attestation/commandrun/tracing_linux.go
@@ -289,21 +289,21 @@ func (p *ptraceContext) waitForExitOnly() error {
 
 func (p *ptraceContext) retryOpenedFiles() {
 	// after tracing, look through opened files to try to resolve any newly created files
-	procInfo := p.getProcInfo(p.traceePid)
+	for _, procInfo := range p.processes {
+		for file, digestSet := range procInfo.OpenedFiles {
+			if digestSet != nil {
+				continue
+			}
 
-	for file, digestSet := range procInfo.OpenedFiles {
-		if digestSet != nil {
-			continue
+			newDigest, err := cryptoutil.CalculateDigestSetFromFile(file, p.hash)
+
+			if err != nil {
+				delete(procInfo.OpenedFiles, file)
+				continue
+			}
+
+			procInfo.OpenedFiles[file] = newDigest
 		}
-
-		newDigest, err := cryptoutil.CalculateDigestSetFromFile(file, p.hash)
-
-		if err != nil {
-			delete(procInfo.OpenedFiles, file)
-			continue
-		}
-
-		procInfo.OpenedFiles[file] = newDigest
 	}
 }
 
@@ -498,3 +498,4 @@ func getSpecBypassIsVulnFromStatus(status []byte) bool {
 
 	return false
 }
+

--- a/attestation/commandrun/tracing_linux_test.go
+++ b/attestation/commandrun/tracing_linux_test.go
@@ -273,3 +273,31 @@ func Test_preExecHookWithTracing(t *testing.T) {
 		t.Error("tracing was enabled but no processes were recorded")
 	}
 }
+
+func Test_tracingChildProcessENOENT(t *testing.T) {
+	cmd := New(
+		WithCommand([]string{"sh", "-c", "cat /tmp/this_file_should_not_exist_in_attestation || true"}),
+		WithSilent(true),
+		WithTracing(true),
+	)
+
+	ctx, err := attestation.NewContext("test", []attestation.Attestor{cmd})
+	if err != nil {
+		t.Fatalf("failed to create attestation context: %v", err)
+	}
+
+	if err := ctx.RunAttestors(); err != nil {
+		t.Fatalf("failed to run attestors: %v", err)
+	}
+
+	if len(cmd.Processes) == 0 {
+		t.Error("tracing was enabled but no processes were recorded")
+	}
+
+	// Verify that the nonexistent file is NOT present in any process's OpenedFiles
+	for _, p := range cmd.Processes {
+		if _, ok := p.OpenedFiles["/tmp/this_file_should_not_exist_in_attestation"]; ok {
+			t.Errorf("found nonexistent file in OpenedFiles for PID %d: %s", p.ProcessID, "/tmp/this_file_should_not_exist_in_attestation")
+		}
+	}
+}

--- a/attestation/commandrun/tracing_linux_test.go
+++ b/attestation/commandrun/tracing_linux_test.go
@@ -17,6 +17,7 @@
 package commandrun
 
 import (
+	"os"
 	"testing"
 
 	"github.com/in-toto/go-witness/attestation"
@@ -275,8 +276,13 @@ func Test_preExecHookWithTracing(t *testing.T) {
 }
 
 func Test_tracingChildProcessENOENT(t *testing.T) {
+	testFile := "/tmp/this_file_should_not_exist_in_attestation"
+	if _, err := os.Stat(testFile); !os.IsNotExist(err) {
+		t.Skipf("skipping test because file %s actually exists on the system", testFile)
+	}
+
 	cmd := New(
-		WithCommand([]string{"sh", "-c", "cat /tmp/this_file_should_not_exist_in_attestation || true"}),
+		WithCommand([]string{"sh", "-c", "cat " + testFile + " || true"}),
 		WithSilent(true),
 		WithTracing(true),
 	)


### PR DESCRIPTION
## What this PR does / why we need it

**Description**

This PR fixes a bug in the `go-witness` tracer where unresolvable nonexistent files (`ENOENT`), such as `systemd` NSS user lookups (e.g., `/etc/userdb/lukp.user`), were leaking into the final attestation's `openedfiles` block as empty objects.

The tracer already has a `retryOpenedFiles()` cleanup loop designed to scrub these unresolved paths. However, it was previously only iterating over the root tracee's `OpenedFiles` (`p.traceePid`). This PR updates `retryOpenedFiles()` to iterate over all tracked processes (`p.processes`). This ensures that if a child process (like `gpg` or `tar`) triggers an unresolvable OS level file lookup, it is properly cleaned up from the final payload.

As part of this fix:
- The temporary `isUserdbPath` filter has been removed, since addressing the core cleanup loop makes explicit path filtering unnecessary.
- Added `Test_tracingChildProcessENOENT` regression test to ensure ENOENT paths accessed by child processes are consistently scrubbed.

## Which issue(s) this PR fixes

Fixes #771 

## Acceptance Criteria Met

- [ ] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)


