### PR TITLE
fix: consolidated coordinated-disclosure security fixes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -42,5 +42,4 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
-          args: --timeout=3m
-          skip-cache: true
+          args: --timeout=10m

--- a/attestation/file/file.go
+++ b/attestation/file/file.go
@@ -15,9 +15,11 @@
 package file
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gobwas/glob"
 	"github.com/in-toto/go-witness/cryptoutil"
@@ -28,6 +30,13 @@ import (
 // If file already exists in baseArtifacts and the two artifacts are equal the artifact will not be in the
 // returned map of artifacts.
 func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}, processWasTraced bool, openedFiles map[string]bool, dirHashGlob []glob.Glob) (map[string]cryptoutil.DigestSet, error) {
+	// Preserve the original attested root across symlink recursion so the boundary check always
+	// compares against the tree the caller asked to attest, not the narrower base of a followed
+	// in-tree symlink.
+	return recordArtifacts(basePath, basePath, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles, dirHashGlob)
+}
+
+func recordArtifacts(basePath, root string, baseArtifacts map[string]cryptoutil.DigestSet, hashes []cryptoutil.DigestValue, visitedSymlinks map[string]struct{}, processWasTraced bool, openedFiles map[string]bool, dirHashGlob []glob.Glob) (map[string]cryptoutil.DigestSet, error) {
 	artifacts := make(map[string]cryptoutil.DigestSet)
 	err := filepath.Walk(basePath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -48,6 +57,18 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 			}
 
 			if dirHashMatch {
+				// Directory hashing follows symlinks when reading file contents, which would
+				// otherwise re-introduce the out-of-tree read the normal walk guards against.
+				// Refuse to hash a directory that contains a symlink resolving outside the
+				// attested path rather than silently hashing the external target.
+				escapes, err := dirHasEscapingSymlink(path, root)
+				if err != nil {
+					return err
+				}
+				if escapes {
+					return fmt.Errorf("(file) refusing to hash directory %v: it contains a symlink resolving outside the attested path", path)
+				}
+
 				dir, err := cryptoutil.CalculateDigestSetFromDir(path, hashes)
 
 				if err != nil {
@@ -71,12 +92,24 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 				return err
 			}
 
+			// Do not follow a symlink whose target resolves outside the tree being attested.
+			// Otherwise a symlink placed in the attested directory could cause out-of-tree files
+			// (secrets, system files) to be opened, hashed, and recorded into the attestation.
+			within, err := pathWithinBase(root, linkedPath)
+			if err != nil {
+				return err
+			}
+			if !within {
+				log.Debugf("(file) skipping symlink %v: target %v resolves outside the attested path", path, linkedPath)
+				return nil
+			}
+
 			if _, ok := visitedSymlinks[linkedPath]; ok {
 				return nil
 			}
 
 			visitedSymlinks[linkedPath] = struct{}{}
-			symlinkedArtifacts, err := RecordArtifacts(linkedPath, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles, dirHashGlob)
+			symlinkedArtifacts, err := recordArtifacts(linkedPath, root, baseArtifacts, hashes, visitedSymlinks, processWasTraced, openedFiles, dirHashGlob)
 			if err != nil {
 				return err
 			}
@@ -105,6 +138,71 @@ func RecordArtifacts(basePath string, baseArtifacts map[string]cryptoutil.Digest
 	})
 
 	return artifacts, err
+}
+
+// pathWithinBase reports whether resolvedTarget (an already symlink-resolved, absolute-or-relative
+// path) is contained within basePath. basePath is canonicalized with EvalSymlinks so the comparison
+// is not defeated by symlinked path components (for example /tmp -> /private/tmp on macOS). It is
+// used to ensure the file attestor does not follow a symlink outside the tree being attested.
+func pathWithinBase(basePath, resolvedTarget string) (bool, error) {
+	absBase, err := filepath.Abs(basePath)
+	if err != nil {
+		return false, err
+	}
+	if canonicalBase, err := filepath.EvalSymlinks(absBase); err == nil {
+		absBase = canonicalBase
+	}
+
+	absTarget, err := filepath.Abs(resolvedTarget)
+	if err != nil {
+		return false, err
+	}
+
+	rel, err := filepath.Rel(absBase, absTarget)
+	if err != nil {
+		return false, nil
+	}
+
+	// The target is within base unless the relative path escapes it with "..".
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// dirHasEscapingSymlink reports whether dir contains any symlink whose target resolves outside
+// basePath. It is used to refuse directory hashing when an out-of-tree symlink is present, since the
+// directory-hash path follows symlinks while reading and cannot selectively exclude them. Broken
+// symlinks are ignored.
+func dirHasEscapingSymlink(dir, basePath string) (bool, error) {
+	found := false
+	err := filepath.Walk(dir, func(p string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode()&fs.ModeSymlink == 0 {
+			return nil
+		}
+
+		resolved, err := filepath.EvalSymlinks(p)
+		if os.IsNotExist(err) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		within, err := pathWithinBase(basePath, resolved)
+		if err != nil {
+			return err
+		}
+		if !within {
+			found = true
+		}
+		return nil
+	})
+
+	return found, err
 }
 
 // shouldRecord determines whether artifact should be recorded.

--- a/attestation/file/file_nonwindow_test.go
+++ b/attestation/file/file_nonwindow_test.go
@@ -90,3 +90,97 @@ func TestDirHashWithSymlink(t *testing.T) {
 
 	require.Equal(t, dirDigestSetMap["dirHash"], dirHashSha256)
 }
+
+// RecordArtifacts must not follow a symlink whose target resolves outside the attested tree; an
+// out-of-tree file reachable only through such a symlink must never be recorded.
+func TestRecordArtifactsSkipsSymlinkOutsideBase(t *testing.T) {
+	// A directory outside the attested tree holding a file that must never be reached.
+	outside := t.TempDir()
+	outsidePath := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("out-of-tree"), 0o600))
+
+	// The attested tree: one in-tree file plus a symlink that escapes to the outside file.
+	base := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(base, "realfile.txt"), []byte("in-tree"), 0o644))
+	require.NoError(t, os.Symlink(outsidePath, filepath.Join(base, "escape.link")))
+
+	artifacts, err := RecordArtifacts(
+		base,
+		map[string]cryptoutil.DigestSet{},
+		[]cryptoutil.DigestValue{{Hash: crypto.SHA256}},
+		map[string]struct{}{},
+		false,
+		map[string]bool{},
+		[]glob.Glob{},
+	)
+	require.NoError(t, err)
+
+	// Nothing recorded should resolve to the out-of-tree file.
+	resolvedOutside, err := filepath.EvalSymlinks(outsidePath)
+	require.NoError(t, err)
+	for recorded := range artifacts {
+		abs, err := filepath.Abs(filepath.Join(base, recorded))
+		require.NoError(t, err)
+		resolved, err := filepath.EvalSymlinks(abs)
+		if err != nil {
+			continue
+		}
+		require.NotEqual(t, resolvedOutside, resolved,
+			"recorded artifact %q resolves outside the attested tree", recorded)
+	}
+}
+
+// Directory hashing follows symlinks while reading file contents and cannot selectively skip an
+// escaping symlink the way the per-file walk does, so RecordArtifacts must fail closed when a hashed
+// directory contains a symlink resolving outside the attested root.
+func TestRecordArtifactsDirHashRefusesEscapingSymlink(t *testing.T) {
+	outside := t.TempDir()
+	outsidePath := filepath.Join(outside, "secret.txt")
+	require.NoError(t, os.WriteFile(outsidePath, []byte("out-of-tree"), 0o600))
+
+	base := t.TempDir()
+	hashedDir := filepath.Join(base, "hasheddir")
+	require.NoError(t, os.Mkdir(hashedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hashedDir, "real.txt"), []byte("in-tree"), 0o644))
+	require.NoError(t, os.Symlink(outsidePath, filepath.Join(hashedDir, "escape.link")))
+
+	dirHash := []glob.Glob{glob.MustCompile("hasheddir")}
+
+	_, err := RecordArtifacts(
+		base,
+		map[string]cryptoutil.DigestSet{},
+		[]cryptoutil.DigestValue{{Hash: crypto.SHA256}},
+		map[string]struct{}{},
+		false,
+		map[string]bool{},
+		dirHash,
+	)
+	require.Error(t, err, "dir-hash mode must refuse a hashed directory containing an escaping symlink")
+	require.Contains(t, err.Error(), "refusing to hash directory")
+}
+
+// The escaping-symlink guard must be specific to symlinks that leave the attested root: a symlink
+// that stays within the root must not block directory hashing.
+func TestRecordArtifactsDirHashAllowsInTreeSymlink(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "target.txt")
+	require.NoError(t, os.WriteFile(target, []byte("in-tree-target"), 0o644))
+
+	hashedDir := filepath.Join(base, "hasheddir")
+	require.NoError(t, os.Mkdir(hashedDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hashedDir, "real.txt"), []byte("in-tree"), 0o644))
+	require.NoError(t, os.Symlink(target, filepath.Join(hashedDir, "intree.link")))
+
+	dirHash := []glob.Glob{glob.MustCompile("hasheddir")}
+
+	_, err := RecordArtifacts(
+		base,
+		map[string]cryptoutil.DigestSet{},
+		[]cryptoutil.DigestValue{{Hash: crypto.SHA256}},
+		map[string]struct{}{},
+		false,
+		map[string]bool{},
+		dirHash,
+	)
+	require.NoError(t, err, "dir-hash mode must allow a hashed directory whose symlink stays within the attested root")
+}

--- a/attestation/system-packages/debian.go
+++ b/attestation/system-packages/debian.go
@@ -41,7 +41,7 @@ func (b *DebianBackend) DetermineOSInfo() (string, string, string, error) {
 }
 
 func (b *DebianBackend) GatherPackages() ([]Package, error) {
-	cmd := b.execCommand("dpkg-query", "-W", "-f", "${Package}\t${Version}\n")
+	cmd := b.execCommand(trustedToolPath("dpkg-query"), "-W", "-f", "${Package}\t${Version}\n")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/attestation/system-packages/rpm.go
+++ b/attestation/system-packages/rpm.go
@@ -71,7 +71,7 @@ func (r *RPMBackend) DetermineOSInfo() (string, string, string, error) {
 }
 
 func (r *RPMBackend) GatherPackages() ([]Package, error) {
-	cmd := r.execCommand("rpm", "-qa", "--qf", "%{NAME}\t%{VERSION}\n")
+	cmd := r.execCommand(trustedToolPath("rpm"), "-qa", "--qf", "%{NAME}\t%{VERSION}\n")
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/attestation/system-packages/trustedpath.go
+++ b/attestation/system-packages/trustedpath.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systempackages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// trustedToolDirs is the fixed set of system directories in which the package-manager binaries are
+// expected to live. The list intentionally does not consult $PATH and intentionally omits
+// /usr/local/bin: distro-packaged managers (rpm, dpkg-query) ship to /usr/bin or /usr/sbin, while
+// /usr/local/bin is the conventional home for locally-installed tooling and is writable in some
+// images and CI runners, which would weaken the trust boundary for no practical gain.
+var trustedToolDirs = []string{"/usr/bin", "/bin", "/usr/sbin", "/sbin"}
+
+// trustedToolPath returns an absolute path to the named package-manager binary, resolved only from a
+// fixed set of trusted system directories rather than from the caller-supplied $PATH. Resolving a
+// bare program name such as "rpm" / "dpkg-query" through $PATH would let whoever controls the
+// environment substitute the binary. When the tool is not present in any trusted directory it
+// returns a conventional absolute path so the command still bypasses $PATH lookup and simply fails
+// to execute if the tool is genuinely absent.
+//
+// name must be a bare file name: callers pass constants, and rejecting anything other than a plain
+// base name (absolute paths, "..", or embedded separators) keeps the trust boundary explicit so a
+// future caller cannot escape trustedToolDirs via filepath.Join cleaning. A rejected name resolves
+// to a path under /dev/null; since /dev/null is a character device, any path traversal through it
+// fails with ENOTDIR, so exec fails closed instead of falling back to $PATH.
+func trustedToolPath(name string) string {
+	if name == "" || name == "." || name == ".." || name != filepath.Base(name) || strings.ContainsRune(name, filepath.Separator) {
+		return filepath.Join(os.DevNull, "invalid-tool-name")
+	}
+
+	for _, dir := range trustedToolDirs {
+		candidate := filepath.Join(dir, name)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+	}
+
+	return filepath.Join("/usr/bin", name)
+}

--- a/attestation/system-packages/trustedpath_test.go
+++ b/attestation/system-packages/trustedpath_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systempackages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// trustedToolPath must resolve the package manager from the fixed trusted directories and never from
+// the caller-supplied $PATH, so a binary planted on $PATH cannot be substituted for the real tool.
+func TestTrustedToolPathIgnoresPATH(t *testing.T) {
+	dir := t.TempDir()
+	planted := filepath.Join(dir, "dpkg-query")
+	require.NoError(t, os.WriteFile(planted, []byte("dummy"), 0o755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	resolved := trustedToolPath("dpkg-query")
+	require.NotEqual(t, planted, resolved, "trustedToolPath resolved the binary from $PATH")
+	require.False(t, strings.HasPrefix(resolved, dir), "trustedToolPath returned a path inside the $PATH directory")
+}
+
+// A name that is not a plain base file name must resolve to the fail-closed sentinel rather than
+// escaping the trusted directories.
+func TestTrustedToolPathRejectsInvalidNames(t *testing.T) {
+	sentinel := filepath.Join(os.DevNull, "invalid-tool-name")
+	for _, name := range []string{"", ".", "..", "a/b", "/etc/evil"} {
+		require.Equal(t, sentinel, trustedToolPath(name), "expected sentinel for name %q", name)
+	}
+}
+
+// The returned path must always be an explicit path (containing a separator) so exec.Command never
+// falls back to a $PATH lookup of a bare program name.
+func TestTrustedToolPathNeverReturnsBareName(t *testing.T) {
+	for _, name := range []string{"rpm", "dpkg-query"} {
+		resolved := trustedToolPath(name)
+		require.NotEqual(t, name, resolved)
+		require.True(t, strings.ContainsRune(resolved, filepath.Separator),
+			"resolved path %q for %q has no separator", resolved, name)
+	}
+}

--- a/cryptoutil/digestset.go
+++ b/cryptoutil/digestset.go
@@ -125,22 +125,63 @@ func HashFromString(name string) (crypto.Hash, error) {
 // Equal returns true if every digest for hash functions both artifacts have in common are equal.
 // If the two artifacts don't have any digests from common hash functions, equal will return false.
 // If any digest from common hash functions differ between the two artifacts, equal will return false.
+//
+// Equality must not silently downgrade to the weakest shared hash: omitting the strong digest could
+// otherwise force a match on a weak one. Equality therefore additionally requires the strongest
+// digest SIZE present on either side to be shared: at least one algorithm in that strongest-size
+// class must appear on both sides and agree, and every shared algorithm in that class must agree.
+// Several algorithms can tie at that size (for example sha256 and gitoid:sha256); sharing any one of
+// them is sufficient. If no algorithm of the strongest size is shared, the sets are not equal.
 func (ds *DigestSet) Equal(second DigestSet) bool {
-	hasMatchingDigest := false
+	// Identify the strongest digest size present across either set (larger digest size == stronger).
+	maxSize := -1
+	for dv := range *ds {
+		if dv.Size() > maxSize {
+			maxSize = dv.Size()
+		}
+	}
+	for dv := range second {
+		if dv.Size() > maxSize {
+			maxSize = dv.Size()
+		}
+	}
+
+	if maxSize < 0 {
+		// Both sets are empty; there is nothing to compare, so they are not equal.
+		return false
+	}
+
+	// At least one algorithm in the strongest-size class must be shared by both sides and agree,
+	// and every shared algorithm in that class must agree. This prevents one side from dropping the
+	// strong digest to force comparison onto a weaker shared algorithm, while remaining
+	// deterministic when several algorithms tie at the strongest size (for example
+	// {sha256, gitoid:sha256}).
+	strongestShared := false
 	for hash, digest := range *ds {
+		if hash.Size() != maxSize {
+			continue
+		}
 		otherDigest, ok := second[hash]
 		if !ok {
 			continue
 		}
+		if digest != otherDigest {
+			return false
+		}
+		strongestShared = true
+	}
+	if !strongestShared {
+		return false
+	}
 
-		if digest == otherDigest {
-			hasMatchingDigest = true
-		} else {
+	// No shared algorithm of any strength may disagree.
+	for hash, digest := range *ds {
+		if otherDigest, ok := second[hash]; ok && digest != otherDigest {
 			return false
 		}
 	}
 
-	return hasMatchingDigest
+	return true
 }
 
 func (ds *DigestSet) ToNameMap() (map[string]string, error) {

--- a/cryptoutil/digestset_test.go
+++ b/cryptoutil/digestset_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil
+
+import (
+	"crypto"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDigestSetEqualRejectsHashDowngrade(t *testing.T) {
+	sha256 := DigestValue{Hash: crypto.SHA256}
+	sha1 := DigestValue{Hash: crypto.SHA1}
+
+	// The full digest set is described by both a strong (SHA-256) and a weak (SHA-1) hash.
+	full := DigestSet{
+		sha256: "3b1f2e8c9d4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9012345abcd",
+		sha1:   "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+	}
+
+	// A different artifact that omits the strong hash and shares only the weak one.
+	weakOnly := DigestSet{
+		sha1: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+	}
+
+	// Equality must not silently downgrade to the weakest shared hash: a set lacking the strong
+	// digest must not compare equal to one that has it.
+	require.False(t, full.Equal(weakOnly),
+		"DigestSet.Equal downgraded to the weakest shared hash; a SHA-1-only digest compared equal to a SHA-256 artifact")
+}
+
+func TestDigestSetEqual_EdgeCases(t *testing.T) {
+	sha256a := DigestValue{Hash: crypto.SHA256}
+	gitoidSHA256 := DigestValue{Hash: crypto.SHA256, GitOID: true} // same 32-byte size as sha256
+	sha1a := DigestValue{Hash: crypto.SHA1}
+
+	const (
+		x256 = "3b1f2e8c9d4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f9012345abcd"
+		y256 = "0000000000000000000000000000000000000000000000000000000000000000"
+		g256 = "gitoid:sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		w1   = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+	)
+
+	tests := []struct {
+		name  string
+		a, b  DigestSet
+		equal bool
+	}{
+		{"both empty are not equal", DigestSet{}, DigestSet{}, false},
+		{"no shared algorithm", DigestSet{sha256a: x256}, DigestSet{sha1a: w1}, false},
+		{"same single strong digest agrees", DigestSet{sha256a: x256}, DigestSet{sha256a: x256}, true},
+		{"strongest digest disagrees", DigestSet{sha256a: x256}, DigestSet{sha256a: y256}, false},
+		{"weaker-side superset still equal on strong", DigestSet{sha256a: x256}, DigestSet{sha256a: x256, sha1a: w1}, true},
+		{"downgrade attempt: strong omitted, weak agrees", DigestSet{sha256a: x256, sha1a: w1}, DigestSet{sha1a: w1}, false},
+		{"tie at strongest size: shared sha256 agrees, gitoid omitted", DigestSet{sha256a: x256, gitoidSHA256: g256}, DigestSet{sha256a: x256}, true},
+		{"tie at strongest size: shared strong disagrees", DigestSet{sha256a: x256, gitoidSHA256: g256}, DigestSet{sha256a: y256}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.equal, tt.a.Equal(tt.b))
+			require.Equal(t, tt.equal, tt.b.Equal(tt.a), "Equal must be symmetric")
+		})
+	}
+}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"reflect"
 
 	"github.com/in-toto/go-witness/cryptoutil"
 	"github.com/in-toto/go-witness/dsse"
@@ -39,6 +40,11 @@ type VerifyPolicySignatureOptions struct {
 	policyOrganizations        []string
 	policyURIs                 []string
 	fulcioCertExtensions       certificate.Extensions
+	// certConstraintsSet records whether the caller explicitly supplied the CN/SAN identity
+	// constraints (via VerifyWithPolicyCertConstraints). When true the supplied values are honored
+	// exactly, so an empty field means "the certificate must have none". When false the caller has
+	// not opted in to SAN/CN constraints, so those fields are not enforced.
+	certConstraintsSet bool
 }
 
 type Option func(*VerifyPolicySignatureOptions)
@@ -68,12 +74,19 @@ func VerifyWithPolicyCAIntermediates(intermediates []*x509.Certificate) Option {
 }
 
 func NewVerifyPolicySignatureOptions(opts ...Option) *VerifyPolicySignatureOptions {
+	// Default the certificate-identity constraints to empty rather than the wildcard "*". An empty
+	// constraint is not AllowAll the way "*" is: checkCertConstraint treats "*" as matching anything,
+	// whereas an empty constraint matches only a certificate that carries no such attribute. More
+	// importantly, the x509 opt-in gate in VerifyPolicySignature refuses an x509 signer entirely until
+	// the caller explicitly configures an identity (CN/SAN constraints or Fulcio extensions), so a
+	// wildcard default would make trusting a CA implicitly trust every certificate that chains to it,
+	// while these empty defaults do not.
 	vo := &VerifyPolicySignatureOptions{
-		policyCommonName:    "*",
-		policyDNSNames:      []string{"*"},
-		policyOrganizations: []string{"*"},
-		policyURIs:          []string{"*"},
-		policyEmails:        []string{"*"},
+		policyCommonName:    "",
+		policyDNSNames:      []string{},
+		policyOrganizations: []string{},
+		policyURIs:          []string{},
+		policyEmails:        []string{},
 	}
 
 	for _, opt := range opts {
@@ -96,7 +109,22 @@ func VerifyWithPolicyCertConstraints(commonName string, dnsNames []string, email
 		vo.policyEmails = emails
 		vo.policyOrganizations = organizations
 		vo.policyURIs = uris
+		vo.certConstraintsSet = true
 	}
+}
+
+// extensionsConfigured reports whether any Fulcio certificate extension constraint was set. It
+// treats any non-zero field as a configured constraint so that constraints remain detected even if
+// Fulcio adds non-string extension fields in the future; relying on the string kind alone would
+// silently fail open for such fields.
+func extensionsConfigured(vo *VerifyPolicySignatureOptions) bool {
+	ev := reflect.ValueOf(vo.fulcioCertExtensions)
+	for i := 0; i < ev.NumField(); i++ {
+		if !ev.Field(i).IsZero() {
+			return true
+		}
+	}
+	return false
 }
 
 func VerifyPolicySignature(ctx context.Context, envelope dsse.Envelope, vo *VerifyPolicySignatureOptions) error {
@@ -107,6 +135,14 @@ func VerifyPolicySignature(ctx context.Context, envelope dsse.Envelope, vo *Veri
 
 	var passed bool
 	for _, verifier := range passedPolicyVerifiers {
+		// A CheckedVerifier whose signature failed cryptographic verification carries a
+		// non-nil Error. Such an entry must never confer trust, regardless of whether its
+		// certificate matches the configured policy constraints.
+		if verifier.Error != nil {
+			log.Debugf("Policy Verifier failed signature verification: %v, continuing...", verifier.Error)
+			continue
+		}
+
 		kid, err := verifier.Verifier.KeyID()
 		if err != nil {
 			return fmt.Errorf("could not get verifier key id: %w", err)
@@ -115,6 +151,18 @@ func VerifyPolicySignature(ctx context.Context, envelope dsse.Envelope, vo *Veri
 		var f policy.Functionary
 		trustBundle := make(map[string]policy.TrustBundle)
 		if _, ok := verifier.Verifier.(*cryptoutil.X509Verifier); ok {
+			// Require an explicit identity opt-in before accepting an x509 policy signer. Trusting a
+			// CA alone must not accept every certificate that chains to it (including an
+			// identity-less certificate, which the empty constraints would otherwise pass since
+			// checkCertConstraint succeeds when both constraint and attribute are empty). The opt-in
+			// is either explicit CN/SAN constraints (VerifyWithPolicyCertConstraints) or Fulcio
+			// extension constraints.
+			extSet := extensionsConfigured(vo)
+			if !vo.certConstraintsSet && !extSet {
+				log.Debugf("Policy Verifier %s is x509 but no certificate identity constraints were configured; refusing, continuing...", kid)
+				continue
+			}
+
 			rootIDs := make([]string, 0)
 			for _, root := range vo.policyCARoots {
 				id := base64.StdEncoding.EncodeToString(root.Raw)
@@ -124,17 +172,31 @@ func VerifyPolicySignature(ctx context.Context, envelope dsse.Envelope, vo *Veri
 				}
 			}
 
+			constraint := policy.CertConstraint{
+				Roots:      rootIDs,
+				Extensions: vo.fulcioCertExtensions,
+			}
+			if vo.certConstraintsSet {
+				// Honor the caller's CN/SAN constraints exactly; an empty field means the
+				// certificate must carry no such value.
+				constraint.CommonName = vo.policyCommonName
+				constraint.DNSNames = vo.policyDNSNames
+				constraint.Emails = vo.policyEmails
+				constraint.Organizations = vo.policyOrganizations
+				constraint.URIs = vo.policyURIs
+			} else {
+				// Only Fulcio extension constraints were configured; the extensions are the identity
+				// opt-in, so do not additionally restrict the CN/SAN fields.
+				constraint.CommonName = "*"
+				constraint.DNSNames = []string{"*"}
+				constraint.Emails = []string{"*"}
+				constraint.Organizations = []string{"*"}
+				constraint.URIs = []string{"*"}
+			}
+
 			f = policy.Functionary{
-				Type: "root",
-				CertConstraint: policy.CertConstraint{
-					Roots:         rootIDs,
-					CommonName:    vo.policyCommonName,
-					URIs:          vo.policyURIs,
-					Emails:        vo.policyEmails,
-					Organizations: vo.policyOrganizations,
-					DNSNames:      vo.policyDNSNames,
-					Extensions:    vo.fulcioCertExtensions,
-				},
+				Type:           "root",
+				CertConstraint: constraint,
 			}
 
 		} else {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -17,7 +17,10 @@ package policy
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"testing"
 	"time"
 
@@ -77,9 +80,20 @@ func TestVerifyPolicySignature(t *testing.T) {
 		{
 			name:   "valid x509 signature",
 			signer: x509Signer,
-			// We're going to pass in to ensure that it is ignored
-			Roots:   []*x509.Certificate{rootCert},
-			wantErr: false,
+			Roots:  []*x509.Certificate{rootCert},
+			// Identity constraints default to empty (fail closed), so trusting a CA requires an
+			// explicit opt-in to accept any certificate under it. An explicit wildcard preserves the
+			// "any cert under the trusted root" behavior.
+			certConstraints: VerifyWithPolicyCertConstraints("*", []string{"*"}, []string{"*"}, []string{"*"}, []string{"*"}),
+			wantErr:         false,
+		},
+		{
+			name:   "valid x509 signature, trusted root but no identity constraints (fails closed)",
+			signer: x509Signer,
+			Roots:  []*x509.Certificate{rootCert},
+			// No certConstraints: with the secure defaults a trusted CA alone must not accept an
+			// arbitrary certificate that chains to it.
+			wantErr: true,
 		},
 		{
 			name:   "valid x509 signature w/ constraints",
@@ -132,4 +146,103 @@ func TestVerifyPolicySignature(t *testing.T) {
 		err = VerifyPolicySignature(context.TODO(), env, vo)
 		assert.Equal(t, err != nil, tt.wantErr, "testName = %s, error = %v, wantErr = %v", tt.name, err, tt.wantErr)
 	}
+}
+
+// createNamedLeaf mints a leaf certificate with a caller-chosen CommonName, signed by the supplied
+// parent (root). It returns the leaf cert and its private key.
+func createNamedLeaf(t *testing.T, parent *x509.Certificate, parentPriv interface{}, commonName string) (*x509.Certificate, *rsa.PrivateKey) {
+	t.Helper()
+	priv, pub, err := test.CreateRsaKey()
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		DNSNames: []string{"in-toto.io"},
+		Subject: pkix.Name{
+			Country:      []string{"US"},
+			Organization: []string{"In-toto"},
+			CommonName:   commonName,
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+	cert, err := test.CreateCert(parentPriv, pub, template, parent)
+	require.NoError(t, err)
+	return cert, priv
+}
+
+// Trusting a CA via VerifyWithPolicyCARoots must not, on its own, accept every certificate that
+// chains to it: an x509 policy signer is refused until the caller explicitly opts in to an identity
+// constraint, so a certificate with an arbitrary identity must be rejected.
+func TestVerifyPolicySignatureRequiresIdentityOptIn(t *testing.T) {
+	root, rootPriv, err := test.CreateRoot()
+	require.NoError(t, err)
+
+	// A leaf with an arbitrary identity that merely chains to the trusted CA.
+	priv, pub, err := test.CreateRsaKey()
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		Subject:               pkix.Name{CommonName: "someone@example.com"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	cert, err := test.CreateCert(rootPriv, pub, tmpl, root)
+	require.NoError(t, err)
+	signer, err := cryptoutil.NewSigner(priv, cryptoutil.SignWithCertificate(cert))
+	require.NoError(t, err)
+
+	env, err := dsse.Sign(intoto.PayloadType, bytes.NewReader([]byte("policy payload")), dsse.SignWithSigners(signer))
+	require.NoError(t, err)
+
+	// Trust the CA but configure no identity constraint (rely on the defaults).
+	vo := NewVerifyPolicySignatureOptions(VerifyWithPolicyCARoots([]*x509.Certificate{root}))
+
+	require.Error(t, VerifyPolicySignature(context.TODO(), env, vo),
+		"trusting a CA without any configured identity constraint must not accept an arbitrary certificate chaining to it")
+}
+
+// A signature that matches the policy's identity constraint but failed cryptographic verification
+// must not confer trust. Here a second signature carries the trusted identity's certificate with
+// forged bytes; only the untrusted identity's signature actually verifies, so the policy must fail.
+func TestVerifyPolicySignatureRejectsFailedVerifier(t *testing.T) {
+	rootCert, rootPriv, err := test.CreateRoot()
+	require.NoError(t, err)
+
+	// A low-value identity that chains to the trusted root and can produce a valid signature.
+	otherCert, otherPriv := createNamedLeaf(t, rootCert, rootPriv, "other-ci@example.com")
+	otherSigner, err := cryptoutil.NewSigner(otherPriv, cryptoutil.SignWithCertificate(otherCert))
+	require.NoError(t, err)
+
+	// The trusted identity's certificate (public only; its private key is not available here).
+	trustedCert, _ := createNamedLeaf(t, rootCert, rootPriv, "release-signer@trusted.example")
+
+	// Sign the policy with the low-value identity: a valid signature that meets the threshold.
+	env, err := dsse.Sign(
+		intoto.PayloadType,
+		bytes.NewReader([]byte("policy payload")),
+		dsse.SignWithSigners(otherSigner),
+	)
+	require.NoError(t, err)
+
+	// Append a second signature carrying the trusted cert with forged bytes.
+	trustedCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: trustedCert.Raw})
+	env.Signatures = append(env.Signatures, dsse.Signature{
+		Certificate: trustedCertPEM,
+		Signature:   []byte("this-signature-was-never-produced-by-the-trusted-signer"),
+	})
+
+	// The policy trusts the release-signer identity (by CommonName) under the trusted root.
+	vo := NewVerifyPolicySignatureOptions(
+		VerifyWithPolicyCARoots([]*x509.Certificate{rootCert}),
+		VerifyWithPolicyCertConstraints(
+			"release-signer@trusted.example",
+			[]string{"*"}, []string{"*"}, []string{"*"}, []string{"*"},
+		),
+	)
+
+	require.Error(t, VerifyPolicySignature(context.TODO(), env, vo),
+		"a certificate whose signature failed verification must not confer trust even when it matches the identity constraint")
 }

--- a/policy/errors.go
+++ b/policy/errors.go
@@ -91,6 +91,15 @@ func (e ErrMismatchArtifact) Error() string {
 	return fmt.Sprintf("mismatched digests for %v", e.Path)
 }
 
+// ErrNoArtifactOverlap is returned when an artifactsFrom comparison finds no path in common between
+// a step's materials and the referenced step's artifacts, meaning nothing actually flowed between
+// the steps and the edge would otherwise pass vacuously.
+type ErrNoArtifactOverlap struct{}
+
+func (e ErrNoArtifactOverlap) Error() string {
+	return "no artifacts in common between the step's materials and the referenced step's artifacts"
+}
+
 type ErrRegoInvalidData struct {
 	Path     string
 	Expected string

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -17,9 +17,14 @@ package policy
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -254,16 +259,15 @@ func (p Policy) Verify(ctx context.Context, opts ...VerifyOption) (bool, map[str
 			stepResult := step.validateAttestations(functionaryCheckResults.Passed)
 			stepResult.Rejected = append(stepResult.Rejected, functionaryCheckResults.Rejected...)
 
-			// We perform many searches against the same step, so we need to merge the relevant fields
-			if resultsByStep[stepName].Step == "" {
-				resultsByStep[stepName] = stepResult
-			} else {
-				if result, ok := resultsByStep[stepName]; ok {
-					result.Passed = append(result.Passed, stepResult.Passed...)
-					result.Rejected = append(result.Rejected, stepResult.Rejected...)
-					resultsByStep[stepName] = result
-				}
-			}
+			// We perform many searches against the same step (once per search-depth iteration), so we
+			// merge the results. A single distinct collection can match on more than one iteration,
+			// so de-duplicate by content identity to avoid counting it multiple times in Passed,
+			// which would otherwise inflate any quorum/coverage decision a consumer makes.
+			merged := resultsByStep[stepName]
+			merged.Step = stepName
+			merged.Passed = appendUniqueCollections(merged.Passed, stepResult.Passed)
+			merged.Rejected = appendUniqueRejected(merged.Rejected, stepResult.Rejected)
+			resultsByStep[stepName] = merged
 
 			for _, coll := range stepResult.Passed {
 				for _, digestSet := range coll.Collection.BackRefs() {
@@ -280,15 +284,121 @@ func (p Policy) Verify(ctx context.Context, opts ...VerifyOption) (bool, map[str
 		return false, nil, fmt.Errorf("failed to verify artifacts: %w", err)
 	}
 
-	pass := true
+	// A policy that defines no steps imposes no requirements and therefore proves nothing; treat it
+	// as a verification failure rather than a vacuous pass.
+	pass := len(p.Steps) > 0
 	for _, result := range resultsByStep {
-		p := result.Analyze()
-		if !p {
+		stepPass := result.Analyze()
+		if !stepPass {
 			pass = false
 		}
 	}
 
 	return pass, resultsByStep, nil
+}
+
+// collectionIdentity derives a content-based identity for a verified collection so the same
+// distinct attestation is recognized across search-depth iterations. It is keyed on the statement
+// content and the verified signer key IDs rather than the envelope reference, because a reference
+// (for example MemorySource's) is only unique within a single source: a MultiSource composed of
+// independent sources can legitimately return distinct envelopes that share a source-local
+// reference, and those must not be collapsed. Identical statement content accepted under different
+// functionaries remains distinct because the verified signer key IDs are part of the identity.
+func collectionIdentity(c source.CollectionVerificationResult) string {
+	h := sha256.New()
+
+	// Length-prefix every field before hashing so the statement bytes and the signer key IDs are
+	// unambiguously framed. Without a delimiter, a concatenation such as statement||signer could in
+	// principle be reproduced by a different (statement, signer-set) pair and collapse two distinct
+	// collections; explicit framing removes that ambiguity.
+	writeField := func(b []byte) {
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(len(b)))
+		h.Write(n[:])
+		h.Write(b)
+	}
+
+	stmt, err := json.Marshal(c.Statement)
+	if err != nil {
+		// A verified statement should always marshal; if it somehow does not, do not silently
+		// collapse this collection with others by contributing nothing. Fold the error into the
+		// identity so an unmarshalable statement stays distinct.
+		stmt = []byte("collectionIdentity: unmarshalable statement: " + err.Error())
+	}
+	writeField(stmt)
+
+	// Key on the verified signer identities, not the raw envelope signature list. DSSE signatures
+	// cover only the payload, so unverified signature entries can be appended without invalidating
+	// the attestation; keying on those would let a duplicate evade de-duplication by changing its
+	// identity. The accepted functionaries' key IDs are trusted and stable across re-signing (unlike
+	// randomized signature bytes). Sort so ordering does not affect the identity.
+	signerSet := make(map[string]struct{}, len(c.ValidFunctionaries))
+	for _, v := range c.ValidFunctionaries {
+		kid, err := v.KeyID()
+		if err != nil {
+			continue
+		}
+		signerSet[kid] = struct{}{}
+	}
+	signers := make([]string, 0, len(signerSet))
+	for kid := range signerSet {
+		signers = append(signers, kid)
+	}
+	sort.Strings(signers)
+	for _, s := range signers {
+		writeField([]byte(s))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// appendUniqueCollections appends additions to existing, skipping any collection whose content
+// identity has already been seen.
+func appendUniqueCollections(existing, additions []source.CollectionVerificationResult) []source.CollectionVerificationResult {
+	seen := make(map[string]struct{}, len(existing))
+	for _, c := range existing {
+		seen[collectionIdentity(c)] = struct{}{}
+	}
+
+	for _, c := range additions {
+		id := collectionIdentity(c)
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		existing = append(existing, c)
+	}
+
+	return existing
+}
+
+// appendUniqueRejected appends rejected collections, collapsing only entries that repeat the same
+// collection AND the same rejection reason across search-depth iterations. The reason is part of the
+// key so a collection that fails several distinct checks keeps every cause for diagnostics.
+func appendUniqueRejected(existing, additions []RejectedCollection) []RejectedCollection {
+	key := func(c RejectedCollection) string {
+		reason := ""
+		if c.Reason != nil {
+			reason = c.Reason.Error()
+		}
+		return collectionIdentity(c.Collection) + "\x00" + reason
+	}
+
+	seen := make(map[string]struct{}, len(existing))
+	for _, c := range existing {
+		seen[key(c)] = struct{}{}
+	}
+
+	for _, c := range additions {
+		k := key(c)
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		existing = append(existing, c)
+	}
+
+	return existing
 }
 
 // checkFunctionaries checks to make sure the signature on each statement corresponds to a trusted functionary for
@@ -305,10 +415,13 @@ func (step Step) checkFunctionaries(statements []source.CollectionVerificationRe
 			for _, verifier := range statement.Verifiers {
 				for _, functionary := range step.Functionaries {
 					if err := functionary.Validate(verifier, trustBundles); err != nil {
-						statements[i].Warnings = append(statement.Warnings, fmt.Sprintf("failed to validate functionary of KeyID %s in step %s: %s", functionary.PublicKeyID, step.Name, err.Error()))
+						// Append to statements[i], not the range-copy `statement`: reading from the
+						// copy (which is never updated in this loop) discards every prior entry, so a
+						// collection with multiple valid functionaries would retain only the last one.
+						statements[i].Warnings = append(statements[i].Warnings, fmt.Sprintf("failed to validate functionary of KeyID %s in step %s: %s", functionary.PublicKeyID, step.Name, err.Error()))
 						continue
 					} else {
-						statements[i].ValidFunctionaries = append(statement.ValidFunctionaries, verifier)
+						statements[i].ValidFunctionaries = append(statements[i].ValidFunctionaries, verifier)
 					}
 				}
 			}
@@ -343,8 +456,8 @@ func (p Policy) verifyArtifacts(resultsByStep map[string]StepResult) (map[string
 		}
 
 		reasons := []error{}
-		for _, collection := range resultsByStep[step.Name].Passed {
-			if err := verifyCollectionArtifacts(step, collection, resultsByStep); err == nil {
+		for i := range resultsByStep[step.Name].Passed {
+			if err := verifyCollectionArtifacts(step, &resultsByStep[step.Name].Passed[i], resultsByStep); err == nil {
 				accepted = true
 			} else {
 				reasons = append(reasons, err)
@@ -370,22 +483,32 @@ func (p Policy) verifyArtifacts(resultsByStep map[string]StepResult) (map[string
 	return resultsByStep, nil
 }
 
-func verifyCollectionArtifacts(step Step, collection source.CollectionVerificationResult, collectionsByStep map[string]StepResult) error {
+func verifyCollectionArtifacts(step Step, collection *source.CollectionVerificationResult, collectionsByStep map[string]StepResult) error {
 	mats := collection.Collection.Materials()
-	reasons := []string{}
 	for _, artifactsFrom := range step.ArtifactsFrom {
-		accepted := make([]source.CollectionVerificationResult, 0)
+		reasons := []string{}
+		seenReasons := map[string]struct{}{}
+		// The edge is satisfied if at least one passed upstream collection genuinely shares an
+		// artifact with this step's materials and every shared digest matches. A candidate that has
+		// no overlap or a mismatching digest is not the source, so skip it and keep looking rather
+		// than terminating on the first non-match. Reasons are de-duplicated so searching multiple
+		// candidates does not repeat the same failure.
+		accepted := make([]source.CollectionVerificationResult, 0, 1)
 		for _, testCollection := range collectionsByStep[artifactsFrom].Passed {
 			if err := compareArtifacts(mats, testCollection.Collection.Artifacts()); err != nil {
-				collection.Warnings = append(collection.Warnings, fmt.Sprintf("failed to verify artifacts for step %s: %v", step.Name, err))
-				reasons = append(reasons, err.Error())
-				break
+				if _, ok := seenReasons[err.Error()]; !ok {
+					seenReasons[err.Error()] = struct{}{}
+					reasons = append(reasons, err.Error())
+					collection.Warnings = append(collection.Warnings, fmt.Sprintf("failed to verify artifacts for step %s: %v", step.Name, err))
+				}
+				continue
 			}
 
 			accepted = append(accepted, testCollection)
+			break
 		}
 
-		if len(accepted) <= 0 {
+		if len(accepted) == 0 {
 			return ErrVerifyArtifactsFailed{Reasons: reasons}
 		}
 	}
@@ -394,12 +517,14 @@ func verifyCollectionArtifacts(step Step, collection source.CollectionVerificati
 }
 
 func compareArtifacts(mats map[string]cryptoutil.DigestSet, arts map[string]cryptoutil.DigestSet) error {
+	overlap := 0
 	for path, mat := range mats {
 		art, ok := arts[path]
 		if !ok {
 			continue
 		}
 
+		overlap++
 		if !mat.Equal(art) {
 			return ErrMismatchArtifact{
 				Artifact: art,
@@ -407,6 +532,13 @@ func compareArtifacts(mats map[string]cryptoutil.DigestSet, arts map[string]cryp
 				Path:     path,
 			}
 		}
+	}
+
+	// An artifactsFrom edge means the downstream materials came from the upstream artifacts. If the
+	// two share no path at all, nothing actually flowed between the steps and the comparison would
+	// otherwise pass vacuously, so reject it.
+	if overlap == 0 {
+		return ErrNoArtifactOverlap{}
 	}
 
 	return nil

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -609,3 +609,85 @@ func TestCheckFunctionaries(t *testing.T) {
 		assert.Equal(t, testCase.expectedResults, resultCheckFields)
 	}
 }
+
+// A single distinct collection that matches on every search-depth iteration must be counted once,
+// not once per iteration.
+func TestVerifyDeduplicatesCollectionsAcrossDepth(t *testing.T) {
+	_, verifier, pubKeyPem, err := createTestKey()
+	require.NoError(t, err)
+	keyID, err := verifier.KeyID()
+	require.NoError(t, err)
+
+	pol := Policy{
+		Expires:    metav1.NewTime(time.Now().Add(time.Hour)),
+		PublicKeys: map[string]PublicKey{keyID: {KeyID: keyID, Key: pubKeyPem}},
+		Steps: map[string]Step{
+			"step1": {Name: "step1",
+				Functionaries: []Functionary{{Type: "PublicKey", PublicKeyID: keyID}},
+				Attestations:  []Attestation{{Type: commandrun.Type}}},
+		},
+	}
+
+	cr := commandrun.New()
+	cr.Cmd = []string{"go", "build"}
+	coll := attestation.NewCollection("step1", []attestation.CompletedAttestor{{Attestor: cr, StartTime: time.Now(), EndTime: time.Now()}})
+	cjson, err := json.Marshal(&coll)
+	require.NoError(t, err)
+	stmt, err := intoto.NewStatement(attestation.CollectionType, cjson, map[string]cryptoutil.DigestSet{"x": {cryptoutil.DigestValue{Hash: crypto.SHA256}: "x"}})
+	require.NoError(t, err)
+
+	one := source.CollectionVerificationResult{
+		Verifiers:          []cryptoutil.Verifier{verifier},
+		CollectionEnvelope: source.CollectionEnvelope{Statement: stmt, Collection: coll, Reference: "1"},
+	}
+
+	_, results, err := pol.Verify(context.Background(),
+		WithSubjectDigests([]string{"x"}),
+		WithSearchDepth(3),
+		WithVerifiedSource(newDummyVerifiedSourcer([]source.CollectionVerificationResult{one})),
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(results["step1"].Passed),
+		"the same collection was merged once per depth iteration instead of being de-duplicated")
+}
+
+// A policy that defines no steps imposes no requirements and must not pass verification.
+func TestVerifyFailsPolicyWithNoSteps(t *testing.T) {
+	pol := Policy{
+		Expires: metav1.NewTime(time.Now().Add(1 * time.Hour)),
+		Steps:   map[string]Step{},
+	}
+
+	pass, _, err := pol.Verify(
+		context.Background(),
+		WithSubjectDigests([]string{"any-subject"}),
+		WithVerifiedSource(newDummyVerifiedSourcer(nil)),
+	)
+	require.NoError(t, err)
+	require.False(t, pass, "a policy that defines no steps proves nothing and must not pass verification")
+}
+
+// An artifactsFrom edge whose downstream materials share no path with the upstream artifacts must be
+// rejected rather than passing vacuously.
+func TestCompareArtifactsRejectsZeroOverlap(t *testing.T) {
+	sha256 := cryptoutil.DigestValue{Hash: crypto.SHA256}
+
+	upstreamArtifacts := map[string]cryptoutil.DigestSet{
+		"bin/app": {sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+	}
+	// Downstream materials share no path with the upstream artifacts: nothing flowed.
+	downstreamMaterials := map[string]cryptoutil.DigestSet{
+		"src/unrelated.go": {sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+	}
+
+	// A genuine overlap with a mismatching digest is rejected.
+	mismatch := map[string]cryptoutil.DigestSet{
+		"bin/app": {sha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+	}
+	require.Error(t, compareArtifacts(mismatch, upstreamArtifacts),
+		"a present artifact with a wrong digest must be rejected")
+
+	require.Error(t, compareArtifacts(downstreamMaterials, upstreamArtifacts),
+		"an artifactsFrom edge with no genuine artifact flow must not pass vacuously")
+}

--- a/policy/step.go
+++ b/policy/step.go
@@ -146,12 +146,15 @@ func (s Step) validateAttestations(collectionResults []source.CollectionVerifica
 	}
 
 	for _, collection := range collectionResults {
-		if collection.Collection.Name != s.Name && collection.Collection.Name != "" {
+		// Require an exact name match. An empty collection name must not act as a wildcard that
+		// matches every step, or a name-agnostic VerifiedSourcer could route an unnamed collection to
+		// a step it was never scoped to.
+		if collection.Collection.Name != s.Name {
 			log.Debugf("Skipping collection %s as it is not for step %s", collection.Collection.Name, s.Name)
 			continue
 		}
 
-		found := make(map[string]attestation.Attestor)
+		found := make(map[string][]attestation.Attestor)
 		reasons := make([]string, 0)
 		passed := true
 		if len(collection.Errors) > 0 {
@@ -161,23 +164,37 @@ func (s Step) validateAttestations(collectionResults []source.CollectionVerifica
 			}
 		}
 
+		// A step that declares no required attestations is a no-op gate: the expected-attestation
+		// loop below never runs, so the collection would be accepted without verifying anything.
+		// Fail closed so an empty attestations list is never a silent pass-through.
+		if len(s.Attestations) == 0 {
+			passed = false
+			reasons = append(reasons, fmt.Sprintf("step %s declares no required attestations; an empty attestations list is not a valid gate", s.Name))
+		}
+
 		for _, attestation := range collection.Collection.Attestations {
-			found[attestation.Type] = attestation.Attestation
+			found[attestation.Type] = append(found[attestation.Type], attestation.Attestation)
 		}
 
 		for _, expected := range s.Attestations {
-			attestor, ok := found[expected.Type]
+			attestors, ok := found[expected.Type]
 			if !ok {
 				passed = false
 				reasons = append(reasons, ErrMissingAttestation{
 					Step:        s.Name,
 					Attestation: expected.Type,
 				}.Error())
+				continue
 			}
 
-			if err := EvaluateRegoPolicy(attestor, expected.RegoPolicies); err != nil {
-				passed = false
-				reasons = append(reasons, err.Error())
+			// Evaluate the rego policy against every attestor of the expected type, not just the
+			// last one. Otherwise a policy-violating attestor could be hidden behind an appended
+			// benign attestor of the same predicate type.
+			for _, attestor := range attestors {
+				if err := EvaluateRegoPolicy(attestor, expected.RegoPolicies); err != nil {
+					passed = false
+					reasons = append(reasons, err.Error())
+				}
 			}
 		}
 

--- a/policy/step_test.go
+++ b/policy/step_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 The Witness Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"crypto"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/in-toto/go-witness/attestation"
+	"github.com/in-toto/go-witness/attestation/commandrun"
+	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/intoto"
+	"github.com/in-toto/go-witness/source"
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// A step that declares no required attestations must not pass a collection unconditionally; it must
+// fail closed with a reason rather than silently accepting or dropping the collection.
+func TestValidateAttestationsFailsOnEmptyAttestations(t *testing.T) {
+	cr := commandrun.New()
+	cr.Cmd = []string{"go", "build"}
+	coll := attestation.NewCollection("build", []attestation.CompletedAttestor{
+		{Attestor: cr, StartTime: time.Now(), EndTime: time.Now()},
+	})
+	cvr := source.CollectionVerificationResult{
+		CollectionEnvelope: source.CollectionEnvelope{Collection: coll, Reference: "1"},
+	}
+
+	step := Step{Name: "build", Attestations: []Attestation{}} // no required attestations
+	result := step.validateAttestations([]source.CollectionVerificationResult{cvr})
+
+	require.Empty(t, result.Passed,
+		"a step with an empty attestations list must not pass a collection")
+	require.NotEmpty(t, result.Rejected,
+		"a step with an empty attestations list must reject the collection, not silently drop it")
+	require.ErrorContains(t, result.Rejected[0].Reason, "no required attestations",
+		"the rejection must explain that an empty attestations list is not a valid gate")
+}
+
+// verifyCollectionNamed runs Verify for a step named "deploy" against a name-agnostic
+// VerifiedSourcer (which returns its collection for any query, modelling a subject-only library
+// source) and reports whether verification passed.
+func verifyCollectionNamed(t *testing.T, collectionName string) bool {
+	_, verifier, pub, err := createTestKey()
+	require.NoError(t, err)
+	keyID, err := verifier.KeyID()
+	require.NoError(t, err)
+	pol := Policy{
+		Expires:    metav1.NewTime(time.Now().Add(time.Hour)),
+		PublicKeys: map[string]PublicKey{keyID: {KeyID: keyID, Key: pub}},
+		Steps: map[string]Step{"deploy": {Name: "deploy",
+			Functionaries: []Functionary{{Type: "PublicKey", PublicKeyID: keyID}},
+			Attestations:  []Attestation{{Type: commandrun.Type}}}},
+	}
+	cr := commandrun.New()
+	cr.Cmd = []string{"go", "build"}
+	coll := attestation.NewCollection(collectionName, []attestation.CompletedAttestor{{Attestor: cr, StartTime: time.Now(), EndTime: time.Now()}})
+	cj, err := json.Marshal(&coll)
+	require.NoError(t, err)
+	stmt, err := intoto.NewStatement(attestation.CollectionType, cj, map[string]cryptoutil.DigestSet{"x": {cryptoutil.DigestValue{Hash: crypto.SHA256}: "x"}})
+	require.NoError(t, err)
+	cvr := source.CollectionVerificationResult{
+		Verifiers:          []cryptoutil.Verifier{verifier},
+		CollectionEnvelope: source.CollectionEnvelope{Statement: stmt, Collection: coll, Reference: "1"},
+	}
+	pass, _, err := pol.Verify(context.Background(), WithSubjectDigests([]string{"x"}),
+		WithVerifiedSource(newDummyVerifiedSourcer([]source.CollectionVerificationResult{cvr})))
+	require.NoError(t, err)
+	return pass
+}
+
+// A collection must carry the step's exact name to be validated against it. An empty collection name
+// must not act as a wildcard that satisfies a differently-named step.
+func TestValidateAttestationsRequiresExactCollectionName(t *testing.T) {
+	require.False(t, verifyCollectionNamed(t, "some-other-step"),
+		"a non-empty mismatched collection name must not satisfy step 'deploy'")
+	require.False(t, verifyCollectionNamed(t, ""),
+		"an empty collection name must not satisfy a differently-named step")
+}
+
+type shadowAttestor struct {
+	Cmd string `json:"cmd"`
+}
+
+func (shadowAttestor) Name() string                                 { return "shadow" }
+func (shadowAttestor) Type() string                                 { return "shadow" }
+func (shadowAttestor) RunType() attestation.RunType                 { return attestation.PreMaterialRunType }
+func (shadowAttestor) Schema() *jsonschema.Schema                   { return jsonschema.Reflect(shadowAttestor{}) }
+func (shadowAttestor) Attest(*attestation.AttestationContext) error { return nil }
+
+// The rego policy must be evaluated against every attestor of the expected type. A policy-violating
+// attestor must not be able to hide behind a benign attestor of the same type appended after it.
+func TestValidateAttestationsEvaluatesAllAttestorsOfType(t *testing.T) {
+	denyDangerous := []byte(`package shadow
+deny[msg] {
+	input.cmd == "rm -rf /"
+	msg := "dangerous command"
+}`)
+
+	step := Step{
+		Name: "build",
+		Attestations: []Attestation{
+			{Type: "shadow", RegoPolicies: []RegoPolicy{{Name: "no-danger", Module: denyDangerous}}},
+		},
+	}
+
+	// Same predicate type twice: the denied attestor first, a benign one appended after.
+	coll := attestation.Collection{
+		Name: "build",
+		Attestations: []attestation.CollectionAttestation{
+			{Type: "shadow", Attestation: shadowAttestor{Cmd: "rm -rf /"}},
+			{Type: "shadow", Attestation: shadowAttestor{Cmd: "make"}},
+		},
+	}
+
+	result := step.validateAttestations([]source.CollectionVerificationResult{
+		{CollectionEnvelope: source.CollectionEnvelope{Collection: coll}},
+	})
+
+	require.Empty(t, result.Passed,
+		"a collection containing a denied attestor must not pass regardless of same-type attestors appended after it")
+}

--- a/timestamp/tsp.go
+++ b/timestamp/tsp.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"encoding/asn1"
 	"fmt"
 	"io"
 	"net/http"
@@ -172,5 +173,70 @@ func (v TSPVerifier) Verify(ctx context.Context, tsrData, signedData io.Reader) 
 		return time.Time{}, err
 	}
 
+	// RFC 3161 requires the TSA signing certificate to carry the id-kp-timeStamping extended key
+	// usage (and only that EKU). VerifyWithChain does not enforce a specific EKU, so a certificate
+	// issued for another purpose (for example TLS server authentication) under the same trust
+	// anchor would otherwise be accepted as a timestamp signer.
+	signer := p7.GetOnlySigner()
+	if signer == nil {
+		return time.Time{}, fmt.Errorf("timestamp token has no single signing certificate")
+	}
+
+	// RFC 3161 section 2.3 requires the timestamping EKU to be the sole extended key usage, so a
+	// multi-purpose certificate (for example one that also bears ServerAuth) must be rejected.
+	if len(signer.ExtKeyUsage) != 1 ||
+		signer.ExtKeyUsage[0] != x509.ExtKeyUsageTimeStamping ||
+		len(signer.UnknownExtKeyUsage) != 0 {
+		return time.Time{}, fmt.Errorf("timestamp signing certificate must carry the id-kp-timeStamping extended key usage as its only EKU")
+	}
+
+	// RFC 3161 section 2.3 also requires that the extended key usage extension be marked critical.
+	if !ekuExtensionIsCritical(signer) {
+		return time.Time{}, fmt.Errorf("timestamp signing certificate extended key usage extension must be marked critical")
+	}
+
+	// p7.VerifyWithChain validates the chain with ExtKeyUsageAny, so an EKU-constrained intermediate
+	// is not caught by the leaf-only check above. Re-verify the chain explicitly requiring the
+	// timestamping EKU so the constraint is enforced through every certificate in the path.
+	//
+	// Only do this when a trust store was configured: with a nil cert pool p7.VerifyWithChain(nil)
+	// intentionally skips chain validation (signature/hash-only mode), and passing Roots: nil to
+	// signer.Verify would silently fall back to the host system roots, changing that behavior.
+	if v.certChain != nil {
+		intermediates := x509.NewCertPool()
+		for _, cert := range p7.Certificates {
+			if cert.Equal(signer) {
+				continue
+			}
+			intermediates.AddCert(cert)
+		}
+		// Verify the chain at the timestamp's own time, not wall-clock time: a timestamp must remain
+		// verifiable after the TSA certificate expires (that is the purpose of timestamping),
+		// matching p7.VerifyWithChain's use of the signing time.
+		if _, err := signer.Verify(x509.VerifyOptions{
+			Roots:         v.certChain,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+			CurrentTime:   ts.Time,
+		}); err != nil {
+			return time.Time{}, fmt.Errorf("timestamp certificate chain is not valid for timestamping: %w", err)
+		}
+	}
+
 	return ts.Time, nil
+}
+
+// oidExtensionExtKeyUsage is the ASN.1 object identifier of the X.509 extended key usage extension.
+var oidExtensionExtKeyUsage = asn1.ObjectIdentifier{2, 5, 29, 37}
+
+// ekuExtensionIsCritical reports whether the certificate's extended key usage extension is present
+// and marked critical, as required of a TSA certificate by RFC 3161 section 2.3.
+func ekuExtensionIsCritical(cert *x509.Certificate) bool {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oidExtensionExtKeyUsage) {
+			return ext.Critical
+		}
+	}
+
+	return false
 }

--- a/timestamp/tsp_test.go
+++ b/timestamp/tsp_test.go
@@ -17,10 +17,18 @@ package timestamp
 import (
 	"bytes"
 	"context"
+	"crypto"
+	"crypto/sha256"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
 	"testing"
+	"time"
 
+	tstamp "github.com/digitorus/timestamp"
 	"github.com/in-toto/go-witness/cryptoutil"
+	"github.com/in-toto/go-witness/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -113,4 +121,134 @@ func TestTSP(t *testing.T) {
 		assert.Error(t, err)
 		assert.Zero(t, signedTime)
 	})
+}
+
+var (
+	oidEKUTimeStamping = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
+	oidEKUServerAuth   = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}
+)
+
+// makeEKUExtension builds an extended-key-usage extension (OID 2.5.29.37) with the given EKU OIDs
+// and criticality. It is needed because x509.CreateCertificate always marks the template
+// ExtKeyUsage field non-critical, while RFC 3161 requires the TSA EKU extension to be critical.
+func makeEKUExtension(t *testing.T, critical bool, ekus ...asn1.ObjectIdentifier) pkix.Extension {
+	t.Helper()
+	val, err := asn1.Marshal(ekus)
+	require.NoError(t, err)
+	return pkix.Extension{Id: asn1.ObjectIdentifier{2, 5, 29, 37}, Critical: critical, Value: val}
+}
+
+// issueAndVerify signs a timestamp with a leaf built from leafTmpl under root, then runs the
+// verifier with root as the sole trust anchor and returns the verifier's result.
+func issueAndVerify(t *testing.T, rootCert *x509.Certificate, rootKey interface{}, leafTmpl *x509.Certificate) (time.Time, error) {
+	t.Helper()
+	leafPriv, leafPub, err := test.CreateRsaKey()
+	require.NoError(t, err)
+	leafCert, err := test.CreateCert(rootKey, leafPub, leafTmpl, rootCert)
+	require.NoError(t, err)
+
+	signedData := []byte("the signature bytes being timestamped")
+	digest := sha256.Sum256(signedData)
+	ts := tstamp.Timestamp{
+		HashAlgorithm:     crypto.SHA256,
+		HashedMessage:     digest[:],
+		Time:              time.Now().UTC(),
+		Nonce:             big.NewInt(0).SetBytes([]byte{0x1, 0x2, 0x3}),
+		Policy:            []int{2, 4, 5, 6},
+		Accuracy:          time.Second,
+		AddTSACertificate: true,
+	}
+	respBytes, err := ts.CreateResponseWithOpts(leafCert, leafPriv, crypto.SHA256)
+	require.NoError(t, err)
+	parsed, err := tstamp.ParseResponse(respBytes)
+	require.NoError(t, err)
+
+	return NewVerifier(VerifyWithCerts([]*x509.Certificate{rootCert})).
+		Verify(context.Background(), bytes.NewReader(parsed.RawToken), bytes.NewReader(signedData))
+}
+
+func baseLeafTemplate(cn string) *x509.Certificate {
+	return &x509.Certificate{
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+}
+
+// A TSA signing certificate that lacks the id-kp-timeStamping EKU (here it carries ServerAuth) must
+// be rejected as a timestamp signer.
+func TestVerifyRejectsCertWithoutTimestampingEKU(t *testing.T) {
+	rootCert, rootKey, err := test.CreateRoot()
+	require.NoError(t, err)
+
+	leafPriv, leafPub, err := test.CreateRsaKey()
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		Subject:               pkix.Name{CommonName: "not-a-timestamper.example"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	leafCert, err := test.CreateCert(rootKey, leafPub, leafTmpl, rootCert)
+	require.NoError(t, err)
+
+	signedData := []byte("the signature bytes being timestamped")
+	digest := sha256.Sum256(signedData)
+	ts := tstamp.Timestamp{
+		HashAlgorithm:     crypto.SHA256,
+		HashedMessage:     digest[:],
+		Time:              time.Now().UTC(),
+		Nonce:             big.NewInt(0).SetBytes([]byte{0x1, 0x2, 0x3}),
+		Policy:            []int{2, 4, 5, 6},
+		Accuracy:          time.Second,
+		AddTSACertificate: true,
+	}
+	respBytes, err := ts.CreateResponseWithOpts(leafCert, leafPriv, crypto.SHA256)
+	require.NoError(t, err)
+	parsed, err := tstamp.ParseResponse(respBytes)
+	require.NoError(t, err)
+
+	_, err = NewVerifier(VerifyWithCerts([]*x509.Certificate{rootCert})).
+		Verify(context.Background(), bytes.NewReader(parsed.RawToken), bytes.NewReader(signedData))
+	require.Error(t, err, "timestamp accepted from a certificate without the id-kp-timeStamping EKU")
+}
+
+// A leaf carrying a sole, critical timestamping EKU is a valid TSA signer and must be accepted.
+func TestVerifyAcceptsSoleCriticalTimestampingEKU(t *testing.T) {
+	rootCert, rootKey, err := test.CreateRoot()
+	require.NoError(t, err)
+	leafTmpl := baseLeafTemplate("valid-tsa.example")
+	leafTmpl.ExtraExtensions = []pkix.Extension{makeEKUExtension(t, true, oidEKUTimeStamping)}
+
+	tt, err := issueAndVerify(t, rootCert, rootKey, leafTmpl)
+	require.NoError(t, err, "a leaf with a sole, critical timestamping EKU must be accepted")
+	require.False(t, tt.IsZero())
+}
+
+// A timestamping EKU that is not marked critical must be rejected, as RFC 3161 requires the EKU
+// extension to be critical.
+func TestVerifyRejectsNonCriticalTimestampingEKU(t *testing.T) {
+	rootCert, rootKey, err := test.CreateRoot()
+	require.NoError(t, err)
+	leafTmpl := baseLeafTemplate("noncritical-tsa.example")
+	leafTmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping} // marked non-critical by Go
+
+	_, err = issueAndVerify(t, rootCert, rootKey, leafTmpl)
+	require.ErrorContains(t, err, "must be marked critical")
+}
+
+// A certificate that carries timestamping alongside another EKU must be rejected: RFC 3161 requires
+// timestamping to be the sole extended key usage.
+func TestVerifyRejectsMultipleEKUs(t *testing.T) {
+	rootCert, rootKey, err := test.CreateRoot()
+	require.NoError(t, err)
+	leafTmpl := baseLeafTemplate("multi-eku-tsa.example")
+	leafTmpl.ExtraExtensions = []pkix.Extension{makeEKUExtension(t, true, oidEKUTimeStamping, oidEKUServerAuth)}
+
+	_, err = issueAndVerify(t, rootCert, rootKey, leafTmpl)
+	require.ErrorContains(t, err, "only EKU")
 }


### PR DESCRIPTION
This PR contains fixes for the below GHSA disclosures. Some where not accepted as vulnerabilities but, code contributions were still accepted for the purpose of defense in depth and more secure defaults. Respective security advisories contain more information.

Fixes:
- GHSA-5qp5-ph6r-qj9f: require a sole, critical id-kp-timeStamping EKU on the TSA signer and re-verify the certificate chain for timestamping.
- GHSA-567m-4668-m656: fail closed when a step declares no required attestations.
- GHSA-rgp5-33mp-jhfm: fail verification for a policy that defines no steps.
- GHSA-r4fv-8r9j-vgcg: evaluate rego against every attestor of a type, not only the last of a duplicated type.
- GHSA-v6px-jqx8-8xwj: refuse to follow or directory-hash symlinks that resolve outside the attested root.
- GHSA-g9jx-rqhm-mj7g: require an exact collection-name match in validateAttestations.
- GHSA-c346-qp3r-53vf: de-duplicate merged step results across search depth.
- GHSA-3vpg-3m94-v3qr: resolve package-manager binaries from trusted directories instead of $PATH.
- GHSA-2v4r-xhmm-ghv8: reject policy verifiers whose signature failed.
- GHSA-mpvw-hw8p-7x27: distinguish explicit-empty certificate constraints from unset and require an identity opt-in for x509 policy signers.
- GHSA-pgpm-j729-qcvh: handle strongest-size hash ties deterministically in DigestSet.Equal.
- GHSA-vmvj-p3hw-39q3: reject zero-overlap artifactsFrom edges and de-duplicate failure reasons.

Assisted-by: Claude Opus 4.8 (1M context)
Assisted-by: Copilot Autofix powered by AI
Assisted-by: Claude Fable 5