### PR TITLE
[cryptoutil] `CalculateDigestSetFile` Fix blocking on FIFO, remove dead if-branches for hashablilty tests.

### DIFF
--- a/cryptoutil/digestset.go
+++ b/cryptoutil/digestset.go
@@ -248,9 +248,6 @@ func CalculateDigestSetFromBytes(data []byte, hashes []DigestValue) (DigestSet, 
 	return CalculateDigestSet(bytes.NewReader(data), hashes)
 }
 
-// ErrNotHashable indicates the target path exists but could not be hashed.
-var ErrNotHashable = errors.New("not a hashable file")
-
 func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, error) {
 	// Use O_NONBLOCK so that FIFO opens are returned immediately instead of hanging/stalling.
 	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
@@ -265,7 +262,7 @@ func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, e
 	}
 
 	if !hashable {
-		return DigestSet{}, fmt.Errorf("%s: %w", path, ErrNotHashable)
+		return DigestSet{}, nil
 	}
 
 	return CalculateDigestSet(file, hashes)

--- a/cryptoutil/digestset.go
+++ b/cryptoutil/digestset.go
@@ -22,6 +22,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"syscall"
 
 	"golang.org/x/mod/sumdb/dirhash"
 )
@@ -247,10 +248,12 @@ func CalculateDigestSetFromBytes(data []byte, hashes []DigestValue) (DigestSet, 
 }
 
 func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, error) {
-	file, err := os.Open(path)
+	// Use O_NONBLOCK so that FIFO opens are returned immediately instead of hanging/stalling.
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		return DigestSet{}, err
 	}
+	defer file.Close()
 
 	hashable, err := isHashableFile(file)
 	if err != nil {
@@ -261,7 +264,6 @@ func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, e
 		return DigestSet{}, fmt.Errorf("%s is not a hashable file", path)
 	}
 
-	defer file.Close()
 	return CalculateDigestSet(file, hashes)
 }
 
@@ -308,26 +310,5 @@ func isHashableFile(f *os.File) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	mode := stat.Mode()
-
-	isSpecial := stat.Mode()&os.ModeCharDevice != 0
-
-	if isSpecial {
-		return false, nil
-	}
-
-	if mode.IsRegular() {
-		return true, nil
-	}
-
-	if mode.Perm().IsDir() {
-		return true, nil
-	}
-
-	if mode&os.ModeSymlink == 1 {
-		return true, nil
-	}
-
-	return false, nil
+	return stat.Mode().IsRegular(), nil
 }

--- a/cryptoutil/digestset.go
+++ b/cryptoutil/digestset.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"crypto"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"hash"
 	"io"

--- a/cryptoutil/digestset.go
+++ b/cryptoutil/digestset.go
@@ -258,7 +258,7 @@ func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, e
 
 	hashable, err := isHashableFile(file)
 	if err != nil {
-		return DigestSet{}, err
+		return DigestSet{}, fmt.Errorf("%s is not a hashable file", path)
 	}
 
 	if !hashable {

--- a/cryptoutil/digestset.go
+++ b/cryptoutil/digestset.go
@@ -258,11 +258,11 @@ func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, e
 
 	hashable, err := isHashableFile(file)
 	if err != nil {
-		return DigestSet{}, fmt.Errorf("%s is not a hashable file", path)
+		return DigestSet{}, err
 	}
 
 	if !hashable {
-		return DigestSet{}, nil
+		return DigestSet{}, fmt.Errorf("%s is not a hashable file", path)
 	}
 
 	return CalculateDigestSet(file, hashes)

--- a/cryptoutil/digestset.go
+++ b/cryptoutil/digestset.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -247,6 +248,9 @@ func CalculateDigestSetFromBytes(data []byte, hashes []DigestValue) (DigestSet, 
 	return CalculateDigestSet(bytes.NewReader(data), hashes)
 }
 
+// ErrNotHashable indicates the target path exists but could not be hashed.
+var ErrNotHashable = errors.New("not a hashable file")
+
 func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, error) {
 	// Use O_NONBLOCK so that FIFO opens are returned immediately instead of hanging/stalling.
 	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
@@ -261,7 +265,7 @@ func CalculateDigestSetFromFile(path string, hashes []DigestValue) (DigestSet, e
 	}
 
 	if !hashable {
-		return DigestSet{}, fmt.Errorf("%s is not a hashable file", path)
+		return DigestSet{}, fmt.Errorf("%s: %w", path, ErrNotHashable)
 	}
 
 	return CalculateDigestSet(file, hashes)

--- a/cryptoutil/digestset_test.go
+++ b/cryptoutil/digestset_test.go
@@ -16,6 +16,9 @@ package cryptoutil
 
 import (
 	"crypto"
+	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -73,6 +76,50 @@ func TestDigestSetEqual_EdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.equal, tt.a.Equal(tt.b))
 			require.Equal(t, tt.equal, tt.b.Equal(tt.a), "Equal must be symmetric")
+		})
+	}
+}
+
+func TestIsHashableFile(t *testing.T) {
+	regular := filepath.Join(t.TempDir(), "regular")
+	require.NoError(t, os.WriteFile(regular, []byte("hello"), 0o644))
+
+	fifo := filepath.Join(t.TempDir(), "fifo")
+	require.NoError(t, syscall.Mkfifo(fifo, 0o600))
+
+	dir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		path     string
+		hashable bool
+	}{
+		{"regular file is hashable", regular, true},
+		{"directory is not hashable", dir, false},
+		{"named pipe is not hashable", fifo, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := os.OpenFile(tt.path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+			require.NoError(t, err)
+			defer f.Close()
+
+			hashable, err := isHashableFile(f)
+			require.NoError(t, err)
+			require.Equal(t, tt.hashable, hashable)
+
+			ds, err := CalculateDigestSetFromFile(tt.path, []DigestValue{{Hash: crypto.SHA256}})
+			if tt.hashable {
+				expected, expErr := CalculateDigestSetFromBytes([]byte("hello"), []DigestValue{{Hash: crypto.SHA256}})
+				require.NoError(t, expErr)
+				require.NoError(t, err)
+				require.Equal(t, expected, ds)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "not a hashable file")
+				require.Equal(t, DigestSet{}, ds)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it

The current test for checking if a filepath is hashable has the following problems that this PR fixes:

1. It blocks indefinitely on FIFOs. This is because before it runs `isHashableFile` it calls `open(O_RDONLY)` on the file which does not immediately return for FIFOs. Since FIFOs are rejected anyway we use `O_NONBLOCK` so that open does not block.

2. `isHashableFile` has a lot of dead paths that are never executed: `mode.Perm().IsDir()` is always false since `Perm()` strips directory identifiers. `ModeSymLink` is not populated since the file is already opened. Checking just for IsRegular meets the same functionality as the current function.

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
