### PR TITLE
policy: predicate-type check in checkFunctionaries never gates acceptance

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -409,6 +409,7 @@ func (step Step) checkFunctionaries(statements []source.CollectionVerificationRe
 		// Check that the statement contains a predicate type that we accept
 		if statement.Statement.PredicateType != attestation.CollectionType {
 			result.Rejected = append(result.Rejected, RejectedCollection{Collection: statement, Reason: fmt.Errorf("predicate type %v is not a collection predicate type", statement.Statement.PredicateType)})
+			continue
 		}
 
 		if len(statement.Verifiers) > 0 {

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -610,6 +610,45 @@ func TestCheckFunctionaries(t *testing.T) {
 	}
 }
 
+// A statement whose predicate type is not a witness collection must never be accepted,
+// even when it carries a valid signature from an authorized functionary. The predicate-type
+// check in checkFunctionaries must gate acceptance, not merely record a rejection reason.
+func TestCheckFunctionariesRejectsNonCollectionPredicate(t *testing.T) {
+	_, verifier, _, err := createTestKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyID, err := verifier.KeyID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	step := Step{
+		Name: "step1",
+		Functionaries: []Functionary{
+			{Type: "PublicKey", PublicKeyID: keyID},
+		},
+		Attestations: []Attestation{
+			{Type: "dummy-prods"},
+		},
+	}
+
+	statements := []source.CollectionVerificationResult{
+		{
+			Verifiers: []cryptoutil.Verifier{verifier},
+			CollectionEnvelope: source.CollectionEnvelope{
+				Statement: intoto.Statement{PredicateType: "https://example.com/not-a-collection/v1"},
+			},
+		},
+	}
+
+	result := step.checkFunctionaries(statements, nil)
+
+	assert.Empty(t, result.Passed, "a non-collection predicate type must not be accepted even with a valid functionary")
+	assert.NotEmpty(t, result.Rejected, "a non-collection predicate type must be rejected")
+}
+
 // A single distinct collection that matches on every search-depth iteration must be counted once,
 // not once per iteration.
 func TestVerifyDeduplicatesCollectionsAcrossDepth(t *testing.T) {


### PR DESCRIPTION
### Summary

The predicate-type check in `Step.checkFunctionaries` (`policy/policy.go`) records a rejection but never gates acceptance, so a statement whose predicate type is not `attestation.CollectionType` can still land in `result.Passed`.

```go
if statement.Statement.PredicateType != attestation.CollectionType {
    result.Rejected = append(result.Rejected, RejectedCollection{...})
}   // no `continue` — falls through to the functionary check below
...
result.Passed = append(result.Passed, statements[i])   // reached even after the rejection above
```

Because `StepResult.Analyze()` passes when `len(Passed) > 0`, the check has no effect on the result — the same statement ends up in both `Rejected` and `Passed`.

### Is this a security issue?

I don't believe it's an exploitable bypass, and I don't want to overstate it. `validateAttestations` still requires the collection name to match the step and the expected attestation types to be present, and the envelope must be signed by an authorized functionary. A genuine non-collection predicate unmarshals to an empty `Collection` and is rejected there. So in practice this reads as dead defense-in-depth / a clarity issue rather than a vulnerability.

### Change

- Add `continue` so a non-collection predicate type is actually rejected.
- Add `TestCheckFunctionariesRejectsNonCollectionPredicate`, asserting such a statement never reaches `Passed` even with a valid functionary. The test fails on `main` (the statement lands in `Passed`) and passes with the one-line change.

If you'd instead prefer to keep relying on the `validateAttestations` backstop, this check is effectively dead code and I'm happy to replace it with a comment instead — whichever you'd like.

`go test ./policy/` passes.
