### PR TITLE
[ptrace commandrun] Club TIDs into TGID/PIDs when reporting process/openedfiles information.

### DIFF
--- a/attestation/commandrun/tracing_linux.go
+++ b/attestation/commandrun/tracing_linux.go
@@ -130,6 +130,7 @@ type ptraceContext struct {
 	traceePid           int
 	mainProgram         string
 	processes           map[int]*ProcessInfo
+	tgidOf              map[int]int // TID -> TGID/PID map
 	exitCode            int
 	hash                []cryptoutil.DigestValue
 	environmentCapturer *environment.Capture
@@ -169,6 +170,7 @@ func (rc *CommandRun) traceWithOptions(c *exec.Cmd, actx *attestation.Attestatio
 		traceePid:    c.Process.Pid,
 		mainProgram:  c.Path,
 		processes:    make(map[int]*ProcessInfo),
+		tgidOf:       map[int]int{c.Process.Pid: c.Process.Pid},
 		executeHooks: rc.executeHooks,
 		hooksOnly:    hooksOnly,
 		hasPreExec:   hasPreExec,
@@ -407,12 +409,23 @@ func (p *ptraceContext) runTrace() error {
 					injectedSig = 0
 
 					switch eventCode {
-					case unix.PTRACE_EVENT_CLONE, unix.PTRACE_EVENT_FORK, unix.PTRACE_EVENT_VFORK:
+					case unix.PTRACE_EVENT_CLONE:
+						// A new thread of an existing process.
 						newTIDMsg, _ := unix.PtraceGetEventMsg(pid)
 						newTID := int(newTIDMsg)
 						if _, known := trackedTIDs[newTID]; !known {
 							trackedTIDs[newTID] = struct{}{}
 						}
+						p.tgidOf[newTID] = p.tgidFor(pid)
+					case unix.PTRACE_EVENT_FORK, unix.PTRACE_EVENT_VFORK:
+						// New process
+						newTIDMsg, _ := unix.PtraceGetEventMsg(pid)
+						newTID := int(newTIDMsg)
+						if _, known := trackedTIDs[newTID]; !known {
+							trackedTIDs[newTID] = struct{}{}
+						}
+						p.tgidOf[newTID] = newTID
+						p.getProcInfo(newTID).ParentPID = p.tgidFor(pid)
 					case unix.PTRACE_EVENT_EXEC:
 						oldTID, err := unix.PtraceGetEventMsg(pid)
 						if err == nil {
@@ -758,9 +771,10 @@ func (p *ptraceContext) handleSyscall(pid int, regs unix.PtraceRegs) error {
 		statusFile, err := os.ReadFile(status)
 		if err == nil {
 			procInfo.SpecBypassIsVuln = getSpecBypassIsVulnFromStatus(statusFile)
-			ppid, err := getPPIDFromStatus(statusFile)
-			if err == nil {
-				procInfo.ParentPID = ppid
+			if procInfo.ParentPID == 0 {
+				if ppid, err := getPPIDFromStatus(statusFile); err == nil {
+					procInfo.ParentPID = ppid
+				}
 			}
 		}
 
@@ -822,7 +836,16 @@ func (p *ptraceContext) handleSyscall(pid int, regs unix.PtraceRegs) error {
 	return nil
 }
 
-func (ctx *ptraceContext) getProcInfo(pid int) *ProcessInfo {
+// tgidFor returns the thread-group (process) id owning pid.
+func (ctx *ptraceContext) tgidFor(pid int) int {
+	if tgid, ok := ctx.tgidOf[pid]; ok {
+		return tgid
+	}
+	return pid
+}
+
+func (ctx *ptraceContext) getProcInfo(tid int) *ProcessInfo {
+	pid := ctx.tgidFor(tid)
 	procInfo, ok := ctx.processes[pid]
 	if !ok {
 		procInfo = &ProcessInfo{


### PR DESCRIPTION
## What this PR does / why we need it

In the current ptrace-based command-run attestor, we report each individual TID that is detected as a separate and standalone process in the final attestation. the "processid" field in these cases are actually the TIDs and the parent processid and program status lines are empty. This makes it impossible to track a file open to a specific program. As an example, consider how the current model works:

```json
[
            {
              "program": "./test",
              "processid": 82996,
              "parentpid": 0,
              "openedfiles": {
                "/etc/ld.so.cache": {
                  "sha256": "62ba8722d57fcf22dc3d5a396e7033f0b978627b8e7d84b9652a0f7ea3d07659"
                },
                "/lib/aarch64-linux-gnu/libc.so.6": {
                  "sha256": "6e3cc56b98887cb3cc2a9fe78b6dd4610184aa27bd05d592cb287db93e82d494"
                },
                "fileA.txt": {
                  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                }
              }
            },
            {
              "processid": 82998,
              "parentpid": 0, // This is a fork(). parentpid is still empty. 
              "openedfiles": {
                "fileC.txt": {
                  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                }
              }
            },
            {
              "processid": 82997,
              "parentpid": 0, // This is a pthread_create. parentpid will always be 0, "program" is always empty for a TID.
              "openedfiles": {
                "fileB.txt": {
                  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                }
              }
            }
]
```

With the changes in this PR this change to a more sensible representation:

```json
[
            {
              "program": "./test",
              "processid": 82876,
              "parentpid": 0, // pthread_create()'d threads are now clubbed under the tgid/pid.
              "openedfiles": {
                "/etc/ld.so.cache": {
                  "sha256": "62ba8722d57fcf22dc3d5a396e7033f0b978627b8e7d84b9652a0f7ea3d07659"
                },
                "/lib/aarch64-linux-gnu/libc.so.6": {
                  "sha256": "6e3cc56b98887cb3cc2a9fe78b6dd4610184aa27bd05d592cb287db93e82d494"
                },
                "fileA.txt": {
                  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                },
                "fileB.txt": {
                  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                }
              }
            },
            {
              "processid": 82878,
              "parentpid": 82876, // fork()'d processes now report parentpid.
              "openedfiles": {
                "fileC.txt": {
                  "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                }
              }
            }
]
```

## Which issue(s) this PR fixes (optional)

(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*

Fixes #

## Acceptance Criteria Met

- [x] Docs changes if needed
- [x] Testing changes if needed
- [ ] All workflow checks passing (automatically enforced)
- [ ] All review conversations resolved (automatically enforced)
- [x] [DCO Sign-off](https://github.com/apps/dco)

**Special notes for your reviewer**:
